### PR TITLE
testing `map[ref.Val]ref.Val` output type

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -66,6 +66,6 @@ func Eval(exp string, input map[string]any) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("failed to marshal the output: %w", err)
 	}
-	b := protojson.Format(jsonData.(*structpb.Value))
-	return string(b), nil
+	out := protojson.Format(jsonData.(*structpb.Value))
+	return out, nil
 }

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -14,7 +14,10 @@
 
 package eval
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 var input = map[string]any{
 	"object": map[string]any{
@@ -49,9 +52,14 @@ func TestEval(t *testing.T) {
 			want: "true",
 		},
 		{
+			name: "query",
+			exp:  "url(object.href).getQuery()",
+			want: `{"query": ["val"]}`,
+		},
+		{
 			name: "regex",
 			exp:  "object.image.find('v[0-9]+.[0-9]+.[0-9]*$')",
-			want: "\"v0.0.0\"",
+			want: `"v0.0.0"`,
 		},
 		{
 			name: "list",
@@ -60,13 +68,13 @@ func TestEval(t *testing.T) {
 		},
 		{
 			name: "optional",
-			exp:  "object.?foo.orValue(\"fallback\")",
-			want: "\"fallback\"",
+			exp:  `object.?foo.orValue("fallback")`,
+			want: `"fallback"`,
 		},
 		{
 			name: "strings",
 			exp:  "object.abc.join(', ')",
-			want: "\"a, b, c\"",
+			want: `"a, b, c"`,
 		},
 		{
 			name: "cross type numeric comparisons",
@@ -86,9 +94,16 @@ func TestEval(t *testing.T) {
 				t.Errorf("Eval() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			if got != tt.want {
+			if stripWhitespace(got) != stripWhitespace(tt.want) {
 				t.Errorf("Eval() got = %v, want %v", got, tt.want)
 			}
 		})
 	}
+}
+
+func stripWhitespace(a string) string {
+	a = strings.ReplaceAll(a, " ", "")
+	a = strings.ReplaceAll(a, "\n", "")
+	a = strings.ReplaceAll(a, "\t", "")
+	return strings.ReplaceAll(a, "\r", "")
 }


### PR DESCRIPTION
## Description
covering `map[ref.Val]ref.Val` output type that was not supported before https://github.com/undistro/cel-playground/pull/15.

## Linked Issues
https://github.com/undistro/cel-playground/pull/15

## How has this been tested?
`make test`

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [x] I have documented my code (if applicable)
- [x] My changes are covered by tests
