### PR TITLE
new: feat: enable content share

### DIFF
--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -35,7 +35,6 @@ a {
 }
 
 .navbar {
-    overflow: hidden;
     background-color: white;
     width: 100%;
     height: 72px;
@@ -75,6 +74,88 @@ a {
     font-size: 16px;
     letter-spacing: 0.01em;
     color: rgba(0, 0, 0, 0.5);
+}
+
+.nav-links {
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    justify-content: right;
+    gap: 16px;
+}
+
+.nav-links > button {
+    height: 40px;
+    white-space: nowrap;
+    display:flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 24px;
+}
+
+.nav-divider {
+    content: '';
+    width: 1px;
+    height: 24px;
+    border-radius: 2px;
+    background: rgba(0, 0, 0, 0.16);
+}
+
+.share-url__container {
+    display: none;
+    height: 40px;
+    padding-left: 8px;
+    justify-content: flex-end;
+    align-items: center;
+    gap: 8px;
+    border-radius: 4px;
+    border: 1px solid #E6E6E6;
+    background: #FFF;
+    position: relative;
+}
+
+.share-url__input {
+    display: flex;
+    width: 220px;
+    flex-direction: column;
+    color: rgba(0, 0, 0, 0.60);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 24px;
+    letter-spacing: 0.12px;
+    border:none;
+}
+
+.share-url__tooltip {
+    color: #3EAA63;
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 120%;
+    letter-spacing: 0.12px;
+    padding: 4px 8px;
+    position: absolute;
+    border-radius: 4px;
+    background: #E6EBE8;
+    right: 0;
+    bottom: -30px;
+    opacity: 0;
+    transition: opacity 0.2s ease-in-out;
+}
+
+.share-url__input:focus {
+    outline: none;
+}
+
+.share-url__copy {
+    display: flex;
+    height: 100%;
+    padding: 8px 12px;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    background: #F5F5F5;
+    border:none;
+    cursor: pointer;
 }
 
 .nav-link {

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -72,18 +72,25 @@ function share() {
 var urlParams = new URLSearchParams(window.location.search);
 if (urlParams.has("content")) {
   const content = urlParams.get("content");
-  const decodedUint8Array = new Uint8Array(
-    atob(content)
-      .split("")
-      .map(function (char) {
-        return char.charCodeAt(0);
-      })
-  );
+  try {
+    const decodedUint8Array = new Uint8Array(
+      atob(content)
+        .split("")
+        .map(function (char) {
+          return char.charCodeAt(0);
+        })
+    );
 
-  const decompressedData = pako.ungzip(decodedUint8Array, { to: "string" });
-  const obj = JSON.parse(decompressedData);
-  celEditor.setValue(obj.expression, -1);
-  dataEditor.setValue(obj.data, -1);
+    const decompressedData = pako.ungzip(decodedUint8Array, { to: "string" });
+    if (!decompressedData) {
+      throw new Error("Invalid content parameter");
+    }
+    const obj = JSON.parse(decompressedData);
+    celEditor.setValue(obj.expression, -1);
+    dataEditor.setValue(obj.data, -1);
+  } catch (error) {
+    console.error(error);
+  }
 }
 
 function copy() {

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -153,9 +153,11 @@ fetch("../assets/data.json")
       option.value = example.name;
       option.innerText = example.name;
 
-      if (example.name === "default" && !urlParams.has("content")) {
-        celEditor.setValue(example.cel, -1);
-        dataEditor.setValue(example.data, -1);
+      if (example.name === "default") {
+        if (!urlParams.has("content")) {
+          celEditor.setValue(example.cel, -1);
+          dataEditor.setValue(example.data, -1);
+        }
       } else {
         examplesList.appendChild(option);
       }

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -63,6 +63,8 @@ function share() {
 
   const url = new URL(window.location.href);
   url.searchParams.set("content", b64encoded_string);
+  window.history.pushState({}, "", url.toString());
+
   document.querySelector(".share-url__container").style.display = "flex";
   document.querySelector(".share-url__input").value = url.toString();
 }

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -45,10 +45,65 @@ function run() {
   output.style.color = isError ? "red" : "white";
 }
 
+
+function share() {
+  const data = dataEditor.getValue();
+  const expression = celEditor.getValue();
+
+  const obj = {
+    data: data,
+    expression: expression,
+  };
+
+  const str = JSON.stringify(obj);
+  var compressed_uint8array = pako.gzip(str);
+  var b64encoded_string = btoa(
+    String.fromCharCode.apply(null, compressed_uint8array)
+  );
+
+  const url = new URL(window.location.href);
+  url.searchParams.set("content", b64encoded_string);
+  document.querySelector(".share-url__container").style.display = "flex";
+  document.querySelector(".share-url__input").value = url.toString();
+}
+
+var urlParams = new URLSearchParams(window.location.search);
+if (urlParams.has("content")) {
+  const content = urlParams.get("content");
+  const decodedUint8Array = new Uint8Array(
+    atob(content)
+      .split("")
+      .map(function (char) {
+        return char.charCodeAt(0);
+      })
+  );
+
+  const decompressedData = pako.ungzip(decodedUint8Array, { to: "string" });
+  const obj = JSON.parse(decompressedData);
+  celEditor.setValue(obj.expression, -1);
+  dataEditor.setValue(obj.data, -1);
+}
+
+function copy() {
+  const copyText = document.querySelector(".share-url__input");
+  copyText.select();
+  copyText.setSelectionRange(0, 99999);
+  navigator.clipboard.writeText(copyText.value);
+  window.getSelection().removeAllRanges();
+
+  const tooltip = document.querySelector(".share-url__tooltip");
+  tooltip.style.opacity = 1;
+  setTimeout(() => {
+    tooltip.style.opacity = 0;
+  }, 3000);
+}
+
 (async function loadAndRunGoWasm() {
   const go = new Go();
 
-  const buffer = pako.ungzip(await (await fetch("assets/main.wasm.gz")).arrayBuffer());
+  const buffer = pako.ungzip(
+    await (await fetch("assets/main.wasm.gz")).arrayBuffer()
+  );
 
   // A fetched response might be decompressed twice on Firefox.
   // See https://bugzilla.mozilla.org/show_bug.cgi?id=610679
@@ -60,7 +115,8 @@ function run() {
     .then((result) => {
       go.run(result.instance);
       document.getElementById("run").disabled = false;
-      document.getElementById("output").placeholder = "Press 'Run' to evaluate your CEL expression.";
+      document.getElementById("output").placeholder =
+        "Press 'Run' to evaluate your CEL expression.";
     })
     .catch((err) => {
       console.error(err);
@@ -68,12 +124,18 @@ function run() {
 })();
 
 const runButton = document.getElementById("run");
+const shareButton = document.getElementById("share");
+const copyButton = document.getElementById("copy");
+
 runButton.addEventListener("click", run);
+shareButton.addEventListener("click", share);
+copyButton.addEventListener("click", copy);
 document.addEventListener("keydown", (event) => {
   if ((event.ctrlKey || event.metaKey) && event.code === "Enter") {
     run();
   }
 });
+
 
 fetch("../assets/data.json")
   .then((response) => response.json())
@@ -89,7 +151,7 @@ fetch("../assets/data.json")
       option.value = example.name;
       option.innerText = example.name;
 
-      if (example.name === "default") {
+      if (example.name === "default" && !urlParams.has("content")) {
         celEditor.setValue(example.cel, -1);
         dataEditor.setValue(example.data, -1);
       } else {

--- a/web/index.html
+++ b/web/index.html
@@ -38,10 +38,52 @@
 			<div class="divider"></div>
 			<span>Quickly test Common Expression Language</span>
 		</div>
-		<a class="nav-link" href="https://github.com/undistro/cel-playground" target="_blank">
-			<img src="assets/img/github.svg" alt="GitHub" />
-			Visit our GitHub
-		</a>
+		<div class="nav-links">
+			<div class="share-url__container">
+				<input type="text" id="share-url" class="share-url__input" placeholder="Share URL" />
+				<button id="copy" class="share-url__copy">
+					<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+						<g clip-path="url(#clip0_148_276)">
+							<path
+								d="M16.875 2.5H6.875C6.70924 2.5 6.55027 2.56585 6.43306 2.68306C6.31585 2.80027 6.25 2.95924 6.25 3.125V6.25H3.125C2.95924 6.25 2.80027 6.31585 2.68306 6.43306C2.56585 6.55027 2.5 6.70924 2.5 6.875V16.875C2.5 17.0408 2.56585 17.1997 2.68306 17.3169C2.80027 17.4342 2.95924 17.5 3.125 17.5H13.125C13.2908 17.5 13.4497 17.4342 13.5669 17.3169C13.6842 17.1997 13.75 17.0408 13.75 16.875V13.75H16.875C17.0408 13.75 17.1997 13.6842 17.3169 13.5669C17.4342 13.4497 17.5 13.2908 17.5 13.125V3.125C17.5 2.95924 17.4342 2.80027 17.3169 2.68306C17.1997 2.56585 17.0408 2.5 16.875 2.5ZM16.25 12.5H13.75V6.875C13.75 6.70924 13.6842 6.55027 13.5669 6.43306C13.4497 6.31585 13.2908 6.25 13.125 6.25H7.5V3.75H16.25V12.5Z"
+								fill="#8447D1" />
+						</g>
+						<defs>
+							<clipPath id="clip0_148_276">
+								<rect width="20" height="20" fill="white" />
+							</clipPath>
+						</defs>
+					</svg>
+				</button>
+				<div class="share-url__tooltip">
+					Copied!
+				</div>
+	
+			</div>
+			<button class="button button-primary" id="share">
+				<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 20 20" fill="none">
+					<g clip-path="url(#clip0_199_15)">
+						<path
+							d="M10.3031 15L9.52657 15.7765C8.82138 16.4703 7.8706 16.8574 6.88134 16.8533C5.89207 16.8493 4.94448 16.4545 4.24496 15.755C3.54544 15.0555 3.15067 14.1079 3.14664 13.1186C3.14261 12.1294 3.52965 11.1786 4.22345 10.4734L6.10704 8.59372C6.78268 7.91671 7.69148 7.52345 8.6475 7.49441C9.60353 7.46536 10.5345 7.80272 11.25 8.43747"
+							stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+						<path
+							d="M9.69688 5.00001L10.4734 4.22345C11.1786 3.52965 12.1294 3.14261 13.1187 3.14664C14.1079 3.15067 15.0555 3.54544 15.7551 4.24496C16.4546 4.94448 16.8493 5.89207 16.8534 6.88134C16.8574 7.8706 16.4704 8.82138 15.7766 9.52658L13.893 11.4102C13.2168 12.0866 12.3078 12.4792 11.3517 12.5075C10.3957 12.5358 9.465 12.1978 8.75 11.5625"
+							stroke="white" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" />
+					</g>
+					<defs>
+						<clipPath id="clip0_199_15">
+							<rect width="20" height="20" fill="white" />
+						</clipPath>
+					</defs>
+				</svg>
+				<p>Share test</p>
+			</button>
+			<div class="nav-divider"></div>
+			<a class="nav-link" href="https://github.com/undistro/cel-playground" target="_blank">
+				<img src="assets/img/github.svg" alt="GitHub" />
+				Visit our GitHub
+			</a>
+		</div>
 	</nav>
 	<main>
 		<div class="editor-container">

--- a/web/index.html
+++ b/web/index.html
@@ -76,7 +76,7 @@
 						</clipPath>
 					</defs>
 				</svg>
-				<p>Share test</p>
+				<p>Share</p>
 			</button>
 			<div class="nav-divider"></div>
 			<a class="nav-link" href="https://github.com/undistro/cel-playground" target="_blank">


### PR DESCRIPTION
## Description
This pull request introduces a new feature that enables data and expression sharing on the website. It allows users to save their expressions and corresponding input data and share them as a link, facilitating easy retrieval of the saved state.

As mentioned in #13, the proposed solution uses a base64 encoded string to represent the saved state. This string is generated from a gzip compressed JSON object containing the expression and input values. By adding this encoded string to the URL, users can easily share the saved state by sharing the URL itself.



## Linked Issues
Closes #13 
