### PR TITLE
feat: add reference links for cel-go in footer (#27)

### DIFF
--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -290,6 +290,17 @@ footer .version {
     border-radius: 4px;
 }
 
+.version a {
+    text-decoration: none;
+    color: inherit;
+}
+
+footer .langdef {
+    padding: 4px 4px;
+    border-radius: 4px;
+    margin-left: auto;
+}
+
 /* Ace Custom */
 
 .ace-clouds .ace_marker-layer .ace_active-line {

--- a/web/index.html
+++ b/web/index.html
@@ -139,8 +139,10 @@
 		<span>Powered by
 			<a href="https://www.getup.io/en/getup-open-source/" target="_blank">Getup</a>
 		</span>
+		<span class="langdef">
+			<a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md" target="_blank">Language Definition</a> |
+		</span>
 		<span class="version">
-			<a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md" target="_blank">Language Definition</a> 
 			<a href="https://github.com/google/cel-go" target="_blank">cel-go</a> <span id="version">...</span>
 		</span>
 	</footer>

--- a/web/index.html
+++ b/web/index.html
@@ -143,7 +143,7 @@
 			<a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md" target="_blank">Language Definition</a> |
 		</span>
 		<span class="version">
-			<a href="https://github.com/google/cel-go" target="_blank">cel-go</a> <span id="version">...</span>
+			<a href="https://github.com/google/cel-go" target="_blank">cel-go <span id="version">...</span></a>
 		</span>
 	</footer>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.2/ace.js"></script>

--- a/web/index.html
+++ b/web/index.html
@@ -140,7 +140,8 @@
 			<a href="https://www.getup.io/en/getup-open-source/" target="_blank">Getup</a>
 		</span>
 		<span class="version">
-			cel-go <span id="version">...</span>
+			<a href="https://github.com/google/cel-spec/blob/master/doc/langdef.md" target="_blank">Language Definition</a> 
+			<a href="https://github.com/google/cel-go" target="_blank">cel-go</a> <span id="version">...</span>
 		</span>
 	</footer>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/ace/1.4.2/ace.js"></script>


### PR DESCRIPTION
## Description
Add reference links for cel-go and Language definition to the footer of the site.

## Linked Issues
Closes #27 
