### PR TITLE
fix: set dropdown color transition to none

### DIFF
--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -466,6 +466,10 @@ footer .langdef {
   text-overflow: ellipsis;
 }
 
+.nice-select.right {
+  transition: none;
+}
+
 .nice-select .optgroup {
   padding-left: 1rem;
 }


### PR DESCRIPTION
## Description
Set dropdown color transition to none. The examples dropdown was shifting colors later (dark/light mode). 

## Linked Issues
-

## Checklist
-