### PR TITLE
Align button

### DIFF
--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -349,7 +349,7 @@ a {
   cursor: pointer;
   position: absolute;
   top: 10px;
-  right: 14px;
+  right: 15px;
   z-index: 1;
   display: flex;
   flex-direction: column;

--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -349,7 +349,7 @@ a {
   cursor: pointer;
   position: absolute;
   top: 10px;
-  right: 30px;
+  right: 14px;
   z-index: 1;
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Description
I've aligned the copy button to the right within the CSS class `editor-copy-btn`. This adjustment makes it closer to [Figma](https://www.figma.com/proto/pasjtGKiZws9pkiVK9Gzp3/Playground?type=design&node-id=406-541&t=t10wMZErSQIppDWt-0&scaling=min-zoom&page-id=0%3A1&starting-point-node-id=406%3A311&hide-ui=1)
