### PR TITLE
Add support for evaluation cost

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/undistro/cel-playground
 
-go 1.20
+go 1.21
 
 require (
 	github.com/google/cel-go v0.16.0

--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -598,3 +598,8 @@ footer .langdef {
   background: #e3e3e3;
   border-radius: 4px;
 }
+
+.cost__header {
+  width: 25%;
+  text-align: left;
+}

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -31,17 +31,29 @@ if (!WebAssembly.instantiateStreaming) {
 
 const celEditor = new AceEditor("cel-input");
 const dataEditor = new AceEditor("data-input");
+const output = document.getElementById("output");
+const costElem = document.getElementById("cost");
+
+function setCost(cost) {
+  costElem.innerText = costElem.textContent = cost;
+}
 
 function run() {
   const data = dataEditor.getValue();
   const expression = celEditor.getValue();
-  const output = document.getElementById("output");
+  const cost = document.getElementById("cost");
 
   output.value = "Evaluating...";
+  setCost("")
+
   const result = eval(expression, data);
 
   const { output: resultOutput, isError } = result;
-  output.value = `${resultOutput}`;
+  var response = JSON.parse(resultOutput);
+
+  output.value = JSON.stringify(response.result);
+  setCost(response.cost);
+
   output.style.color = isError ? "red" : "white";
 }
 
@@ -304,6 +316,8 @@ fetch("../assets/data.json")
       );
       celEditor.setValue(example.cel, -1);
       dataEditor.setValue(example.data, -1);
+      setCost("");
+      output.value = "";
     });
   })
   .catch((err) => {

--- a/web/dist/wasm_exec.js
+++ b/web/dist/wasm_exec.js
@@ -113,6 +113,10 @@
 				this.mem.setUint32(addr + 4, Math.floor(v / 4294967296), true);
 			}
 
+			const setInt32 = (addr, v) => {
+				this.mem.setUint32(addr + 0, v, true);
+			}
+
 			const getInt64 = (addr) => {
 				const low = this.mem.getUint32(addr + 0, true);
 				const high = this.mem.getInt32(addr + 4, true);
@@ -206,7 +210,10 @@
 
 			const timeOrigin = Date.now() - performance.now();
 			this.importObject = {
-				go: {
+				_gotest: {
+					add: (a, b) => a + b,
+				},
+				gojs: {
 					// Go's SP does not change as long as no Go code is running. Some operations (e.g. calls, getters and setters)
 					// may synchronously trigger a Go event handler. This makes Go code get executed in the middle of the imported
 					// function. A goroutine can switch to a new stack if the current stack is too small (see morestack function).
@@ -269,7 +276,7 @@
 									this._resume();
 								}
 							},
-							getInt64(sp + 8) + 1, // setTimeout has been seen to fire up to 1 millisecond early
+							getInt64(sp + 8),
 						));
 						this.mem.setInt32(sp + 16, id, true);
 					},

--- a/web/index.html
+++ b/web/index.html
@@ -144,7 +144,15 @@
 				</div>
 				<div class="editor editor--output">
 					<div class="editor__header">
-						Output
+						<span>
+							Output
+						</span>
+						<span class="cost__header">
+							<span>
+								Cost:
+							</span>
+							<span id="cost"></span>
+						</span>
 					</div>
 					<textarea id="output" class="editor__output"
 						placeholder="Loading Wasm…" disabled></textarea>


### PR DESCRIPTION
## Description
Adding support for evaluation costs

Note: this PR also updated the wasm exec js library to the version from go.1.21.3, if this is a problem I can roll back to 1.20

## Linked Issues
Closes https://github.com/undistro/cel-playground/issues/34

## How has this been tested?
- Test cases updated
- Ran evaluation in browser and checked that
  - Cost was displayed
  - Choosing new expression from drop down would reset cost/output

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [X] My changes are covered by tests
