### PR TITLE
fix link for new getup website

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -228,7 +228,7 @@
     <footer>
       <span
         >Powered by
-        <a href="https://www.getup.io/en/getup-open-source/" target="_blank"
+        <a href="https://getup.io/en/opensource" target="_blank"
           >Getup</a
         >
       </span>


### PR DESCRIPTION
## Description
Hi everyone!

We should fix the URL on "Powered by Getup"  localized on footer from CEL - Playground.

The current URL is linked for page with status 404. Now, the correct URL is:  https://getup.io/en/opensource 
I just added this little fix.

## How has this been tested?
On branch **fix-link-to-getup**, run `make serve ` and click "Powered by GetUp"

## Checklist
- [x] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [ ] My changes are covered by tests
