### PR TITLE
Add CEL and Kubernetes to the list of CEL Playground adopters

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -4,6 +4,9 @@ This list shows adopters of CEL-Playground. If you're using CEL Playground in an
 
 ## Adopters list (alphabetical)
 
+* [CEL](https://cel.dev) - CEL team refers users to the CEL Playground by Undistro when community members ask for help getting started. This has proven to be a valuable support tool and an important tool in helping people learn how to wield the language.
 * [Getup](https://getup.io) - Getup is the original author of CEL Playground, we use the playground with our customers to help them learn how to make use of CEL within Kubernetes
 * [Ifood](https://www.ifood.com.br/) - Cel Playground helps me a lot in my CEL expression studies and is a valuable partner when it comes to important implementations in quick tests and immediate feedback, in addition to being able to simulate real scenarios. I love this tool.
+* [Kubernetes](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy) - CEL Playground is referenced within Kubernetes Validating Admission Policy to help users familiarize themselves with CEL before they try using it in their deployment.
 * [LINUXtips](https://linuxtips.io) - LINUXtips effectively utilizes CEL Playground to support students in grasping the implementation of security policies using CEL. This valuable resource enables students to actively test and apply what they are learning in a practical way, helping them gain a deeper understanding of real-world applications.
+


### PR DESCRIPTION
## Description
Add CEL and Kubernetes to the list of CEL Playground adopters.

## Linked Issues
N/A

## How has this been tested?
Purely a documentation change.

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [X] I have documented my code (if applicable)
- [X] My changes are covered by tests
