### PR TITLE
increase security of example (#105)

### DIFF
--- a/examples.yaml
+++ b/examples.yaml
@@ -43,7 +43,7 @@ examples:
       object.spec.template.spec.containers.all(container,
         params.allowedRegistries.exists(registry,
           ((registry in ['docker.io', 'docker.io/library']) && !container.image.contains('/')) ||
-          container.image.startsWith(registry)
+          container.image.startsWith(registry + '/')
         )
       )
     dataInput: |

--- a/web/assets/examples/cel.json
+++ b/web/assets/examples/cel.json
@@ -8,7 +8,7 @@
     },
     {
       "name": "Check image registry",
-      "cel": "object.spec.template.spec.containers.all(container,\n  params.allowedRegistries.exists(registry,\n    ((registry in ['docker.io', 'docker.io/library']) && !container.image.contains('/')) ||\n    container.image.startsWith(registry)\n  )\n)\n",
+      "cel": "object.spec.template.spec.containers.all(container,\n  params.allowedRegistries.exists(registry,\n    ((registry in ['docker.io', 'docker.io/library']) && !container.image.contains('/')) ||\n    container.image.startsWith(registry + '/')\n  )\n)\n",
       "dataInput": "params:\n  allowedRegistries: \n    - myregistry.com\n    - docker.io # use 'docker.io' for Docker Hub\nobject:\n  apiVersion: apps/v1\n  kind: Deployment\n  metadata:\n    name: nginx\n  spec:\n    template:\n      metadata:\n        name: nginx\n        labels:\n          app: nginx\n      spec:\n        containers:\n          - name: nginx\n            image: nginx # the expression looks for this field\n    selector:\n      matchLabels:\n        app: nginx\n",
       "category": "Kubernetes"
     },


### PR DESCRIPTION
## Description
The example CEL Expression "Check image registry" did not consider the case where a bad actor prepends a trusted hostname to their hostname as a subdomain. 

For Example:
Trusted registry: myregistry.com/nginx
Spoof registry: myregistry.com.bad.actor.com/nginx

## Linked Issues
fix #105

## How has this been tested?
I ran `make test` with result:
```
go test ./... -coverprofile cover.out
        github.com/undistro/cel-playground/cmd/server           coverage: 0.0% of statements
ok      github.com/undistro/cel-playground/eval 0.027s  coverage: 67.6% of statements
ok      github.com/undistro/cel-playground/k8s  0.039s  coverage: 67.4% of statements
```
I also ran the `make serve` and then checked the trusted and spoof registry imagees mentioned above

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [X] I have documented my code (if applicable) (it was not applicable)
- [X] My changes are covered by tests
