### PR TITLE
fix: address ConvertToNative failures when dereferencing optional.none()

### DIFF
--- a/eval/eval.go
+++ b/eval/eval.go
@@ -17,14 +17,13 @@ package eval
 import (
 	"encoding/json"
 	"fmt"
-	"reflect"
 
 	"github.com/google/cel-go/cel"
 	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/common/types/ref"
 	"github.com/google/cel-go/ext"
 	"github.com/google/cel-go/interpreter"
-	"google.golang.org/protobuf/types/known/structpb"
+	"github.com/undistro/cel-playground/utils"
 	"gopkg.in/yaml.v2"
 	k8s "k8s.io/apiserver/pkg/cel/library"
 )
@@ -120,8 +119,8 @@ func Eval(exp string, input map[string]any) (string, error) {
 	return string(out), nil
 }
 
-func getResults(val *ref.Val) (any, error) {
-	if value, err := (*val).ConvertToNative(reflect.TypeOf(&structpb.Value{})); err != nil {
+func getResults(val ref.Val) (any, error) {
+	if value, err := utils.ConvertValToNative(val); err != nil {
 		return nil, err
 	} else {
 		return value, nil
@@ -129,7 +128,7 @@ func getResults(val *ref.Val) (any, error) {
 }
 
 func generateResponse(val ref.Val, costTracker *cel.EvalDetails) (*EvalResponse, error) {
-	result, evalError := getResults(&val)
+	result, evalError := getResults(val)
 	if evalError != nil {
 		return nil, evalError
 	}

--- a/eval/eval_test.go
+++ b/eval/eval_test.go
@@ -32,6 +32,11 @@ var input = map[string]any{
 		"abc":      []string{"a", "b", "c"},
 		"memory":   "1.3G",
 	},
+	"nested": []any{
+		map[string]any{
+			"name": "test",
+		},
+	},
 }
 
 func TestEval(t *testing.T) {
@@ -153,6 +158,20 @@ func TestEval(t *testing.T) {
 			name: "sets.intersects test 3",
 			exp:  `sets.intersects([[1], [2, 3]], [[1, 2], [2, 3]])`,
 			want: true,
+		},
+		{
+			name: "optional list",
+			exp:  `nested.map(m, m.?optional)`,
+			want: []any{nil},
+		},
+		{
+			name: "optional map",
+			exp:  `nested.map(m, {m.name: m.?optional})`,
+			want: []any{
+				map[string]any{
+					"test": nil,
+				},
+			},
 		},
 	}
 	for _, tt := range tests {

--- a/k8s/testdata/vap/optional_none_dereference policy.yaml
+++ b/k8s/testdata/vap/optional_none_dereference policy.yaml
@@ -1,0 +1,30 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "pod-security.policy.example.com"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["apps"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["deployments"]
+  variables:
+  - name: containers
+    expression: object.spec.template.spec.containers
+  - name: securityContexts
+    expression: 'variables.containers.map(c, c.?securityContext)'
+  - name: namedSecurityContexts
+    expression: 'variables.containers.map(c, {c.name: c.?securityContext})'
+  validations:
+  - expression: variables.securityContexts.all(c, c.?runAsNonRoot == optional.of(true))
+    message: 'all containers must set runAsNonRoot to true'
+  - expression: variables.securityContexts.all(c, c.?readOnlyRootFilesystem == optional.of(true))
+    message: 'all containers must set readOnlyRootFilesystem to true'
+  - expression: variables.securityContexts.all(c, c.?allowPrivilegeEscalation != optional.of(true))
+    message: 'all containers must NOT set allowPrivilegeEscalation to true'
+  - expression: variables.securityContexts.all(c, c.?privileged != optional.of(true))
+    message: 'all containers must NOT set privileged to true'
+  - expression: variables.namedSecurityContexts.all(c, c.?securityContext.privileged != optional.of(true))
+    message: 'all named containers must NOT set privileged to true'

--- a/k8s/testdata/vap/optional_none_dereference updated.yaml
+++ b/k8s/testdata/vap/optional_none_dereference updated.yaml
@@ -1,0 +1,37 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app: kubernetes-bootcamp
+  name: kubernetes-bootcamp
+  namespace: default
+spec:
+  progressDeadlineSeconds: 600
+  replicas: 3
+  revisionHistoryLimit: 10
+  selector:
+    matchLabels:
+      app: kubernetes-bootcamp
+  strategy:
+    rollingUpdate:
+      maxSurge: 25%
+      maxUnavailable: 25%
+    type: RollingUpdate
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        app: kubernetes-bootcamp
+    spec:
+      containers:
+      - image: gcr.io/google-samples/kubernetes-bootcamp:v1
+        imagePullPolicy: IfNotPresent
+        name: kubernetes-bootcamp
+        resources: {}
+        terminationMessagePath: /dev/termination-log
+        terminationMessagePolicy: File
+      dnsPolicy: ClusterFirst
+      restartPolicy: Always
+      schedulerName: default-scheduler
+      securityContext: {}
+      terminationGracePeriodSeconds: 30

--- a/k8s/validatingadmissionpolicy_test.go
+++ b/k8s/validatingadmissionpolicy_test.go
@@ -326,6 +326,59 @@ func TestValidationEval(t *testing.T) {
 			}},
 			Cost: uint64ptr(8),
 		},
+	}, {
+		name:    "test optional.none() dereference",
+		policy:  "optional_none_dereference policy.yaml",
+		orig:    "",
+		updated: "optional_none_dereference updated.yaml",
+
+		expected: k8s.EvalResponse{
+			ValidationVariables: []*k8s.EvalVariable{{
+				Name: "containers",
+				Value: []any{
+					map[string]any{
+						"image":                    "gcr.io/google-samples/kubernetes-bootcamp:v1",
+						"imagePullPolicy":          "IfNotPresent",
+						"name":                     "kubernetes-bootcamp",
+						"resources":                map[string]any{},
+						"terminationMessagePath":   "/dev/termination-log",
+						"terminationMessagePolicy": "File",
+					},
+				},
+				Cost: uint64ptr(5),
+			}, {
+				Name:  "securityContexts",
+				Value: []any{nil},
+				Cost:  uint64ptr(15),
+			}, {
+				Name: "namedSecurityContexts",
+				Value: []any{
+					map[string]any{
+						"kubernetes-bootcamp": nil,
+					},
+				},
+				Cost: uint64ptr(47),
+			}},
+			Validations: []*k8s.EvalResult{{
+				Result:  false,
+				Message: "all containers must set runAsNonRoot to true",
+				Cost:    uint64ptr(8),
+			}, {
+				Result:  false,
+				Message: "all containers must set readOnlyRootFilesystem to true",
+				Cost:    uint64ptr(8),
+			}, {
+				Result: true,
+				Cost:   uint64ptr(8),
+			}, {
+				Result: true,
+				Cost:   uint64ptr(8),
+			}, {
+				Result: true,
+				Cost:   uint64ptr(8),
+			}},
+			Cost: uint64ptr(107),
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/utils/conversion.go
+++ b/utils/conversion.go
@@ -1,0 +1,87 @@
+// Copyright 2025 Undistro Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package utils
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+
+	"github.com/google/cel-go/common/types"
+	"github.com/google/cel-go/common/types/ref"
+	"github.com/google/cel-go/common/types/traits"
+	"google.golang.org/protobuf/types/known/structpb"
+)
+
+type conversionTraits interface {
+	traits.Iterable
+	traits.Indexer
+}
+
+var stringType = reflect.TypeOf("")
+
+func ConvertValToNative(val ref.Val) (any, error) {
+	valType := val.Type()
+	switch valType {
+	case types.ListType:
+		if iterable, ok := val.(conversionTraits); !ok {
+			return nil, errors.New("type conversion error from list to iterable")
+		} else {
+			values := []any{}
+			iter := iterable.Iterator()
+			for iter.HasNext() == types.True {
+				if value, err := ConvertValToNative(iter.Next()); err != nil {
+					return nil, err
+				} else {
+					values = append(values, value)
+				}
+			}
+			return values, nil
+		}
+	case types.MapType:
+		if iterable, ok := val.(conversionTraits); !ok {
+			return nil, errors.New("type conversion error from map to iterable")
+		} else {
+			values := map[string]any{}
+			iter := iterable.Iterator()
+			for iter.HasNext() == types.True {
+				keyVal := iter.Next()
+				if key, err := keyVal.ConvertToNative(stringType); err != nil {
+					return nil, fmt.Errorf("unexpected map key type: %v", keyVal.Type())
+				} else if value, err := ConvertValToNative(iterable.Get(keyVal)); err != nil {
+					return nil, err
+				} else {
+					values[key.(string)] = value
+				}
+			}
+			return values, nil
+		}
+	case types.OptionalType:
+		opt, ok := val.(*types.Optional)
+		if !ok {
+			return nil, errors.New("type conversion error for optional")
+		} else if !opt.HasValue() {
+			return nil, nil
+		}
+		val = opt.GetValue()
+		fallthrough
+	default:
+		if value, err := val.ConvertToNative(reflect.TypeOf(&structpb.Value{})); err != nil {
+			return nil, err
+		} else {
+			return value, nil
+		}
+	}
+}


### PR DESCRIPTION
## Description
This PR works around the issue caused when CEL converts optional.none() values to a native type.  The code handles optionals in list values, map values and as the root object.

## Linked Issues
#104 

## How has this been tested?
- Tests are included in the PR

## Checklist
- [X] I have labeled this PR with the relevant [Type labels](https://github.com/undistro/.github/labels?q=Type%3A)
- [ ] I have documented my code (if applicable)
- [X] My changes are covered by tests
