### PR TITLE
k8s: charge the apiserver's CEL costs in the k8s modes

### DIFF
--- a/k8s/cel.go
+++ b/k8s/cel.go
@@ -16,7 +16,9 @@ package k8s
 
 import (
 	"github.com/google/cel-go/cel"
+	"github.com/google/cel-go/checker"
 	"github.com/google/cel-go/ext"
+	"github.com/google/cel-go/interpreter"
 	k8s "k8s.io/apiserver/pkg/cel/library"
 )
 
@@ -46,8 +48,28 @@ var celEnvOptions = []cel.EnvOption{
 	k8s.CIDR(),                          // 1.30
 	k8s.Format(),                        // 1.31
 	k8s.SemverLib(k8s.SemverVersion(1)), // 1.33
+
+	// Cost accounting, also from apiserver's base.go, so a displayed cost is
+	// close to what a real cluster charges: the k8s CostEstimator in the program
+	// options below prices the extended-library functions (ip, cidr, url,
+	// semver, ...) and, most visibly, an authorizer check() at its real 350000
+	// instead of cel-go's defaults.
+	//
+	// Close, not exact. Expressions using variables.*, string concatenation or
+	// `in` over a typed list still undercharge slightly, because this env parses
+	// expressions (env.Parse) where the apiserver compiles and type-checks them,
+	// so those overloads fall back to cel-go's default cost. Closing that gap
+	// means switching Parse to Compile, a separate change.
+	//
+	// CostEstimatorOptions is currently a no-op -- nothing here runs the static
+	// estimator, only Parse and eval -- but it is kept so this stays a faithful
+	// mirror of base.go, and it becomes load-bearing the moment anyone switches
+	// to Compile. Do not delete it as dead code.
+	cel.CostEstimatorOptions(checker.PresenceTestHasCost(false)),
 }
 
 var celProgramOptions = []cel.ProgramOption{
 	cel.EvalOptions(cel.OptOptimize, cel.OptTrackCost),
+	cel.CostTrackerOptions(interpreter.PresenceTestHasCost(false)),
+	cel.CostTracking(&k8s.CostEstimator{}),
 }

--- a/k8s/validatingadmissionpolicy_test.go
+++ b/k8s/validatingadmissionpolicy_test.go
@@ -139,10 +139,10 @@ func TestValidationEval(t *testing.T) {
 				Value: map[string]any{
 					"query": []any{"val"},
 				},
-				Cost: uint64ptr(14),
+				Cost: uint64ptr(19),
 			}},
 			Validations: []*k8s.EvalResult{{Result: true, Cost: uint64ptr(2)}},
-			Cost:        uint64ptr(16),
+			Cost:        uint64ptr(21),
 		},
 	}, {
 		name:    "test valid matchConditions, should see validations and auditAnnotations",
@@ -268,14 +268,14 @@ func TestValidationEval(t *testing.T) {
 			}},
 			Validations: []*k8s.EvalResult{{
 				Result: true,
-				Cost:   uint64ptr(10),
+				Cost:   uint64ptr(350009),
 			}},
 			AuditAnnotations: []*k8s.EvalResult{{
 				Name:    strptr("test-annotation"),
 				Message: "Deployment is allowed in namespace default",
 				Cost:    uint64ptr(4),
 			}},
-			Cost: uint64ptr(23),
+			Cost: uint64ptr(350022),
 		},
 	}, {
 		name:       "test an expression using disallowed authorizer checks",
@@ -296,9 +296,9 @@ func TestValidationEval(t *testing.T) {
 			}},
 			Validations: []*k8s.EvalResult{{
 				Result: false,
-				Cost:   uint64ptr(10),
+				Cost:   uint64ptr(350009),
 			}},
-			Cost: uint64ptr(19),
+			Cost: uint64ptr(350018),
 		},
 	}, {
 		name:    "test a broken expression within variables, expression should fail with no audit annotation",

--- a/k8s/webhook_test.go
+++ b/k8s/webhook_test.go
@@ -89,9 +89,9 @@ func TestWebhookEval(t *testing.T) {
 		authorizer: "authorizer4.yaml",
 		expected: k8s.EvalResponse{
 			WebhookMatchConditions: [][]*k8s.EvalResult{{
-				{Name: strptr("breakglass"), Result: true, Cost: uint64ptr(7)},
+				{Name: strptr("breakglass"), Result: true, Cost: uint64ptr(350006)},
 			}},
-			Cost: uint64ptr(7),
+			Cost: uint64ptr(350006),
 		},
 	}, {
 		name:       "test multiple webhooks, match conditions will rely on request and authorizer information and will be successful",
@@ -101,10 +101,10 @@ func TestWebhookEval(t *testing.T) {
 		authorizer: "multi authorizer1.yaml",
 		expected: k8s.EvalResponse{
 			WebhookMatchConditions: [][]*k8s.EvalResult{
-				{{Name: strptr("breakglass"), Result: true, Cost: uint64ptr(7)}},
+				{{Name: strptr("breakglass"), Result: true, Cost: uint64ptr(350006)}},
 				{{Name: strptr("exclude-leases"), Result: true, Cost: uint64ptr(5)}, {Name: strptr("exclude-kubelet-requests"), Result: true, Cost: uint64ptr(5)}},
 			},
-			Cost: uint64ptr(17),
+			Cost: uint64ptr(350016),
 		},
 	}, {
 		name:       "test multiple webhooks, match conditions will rely on request and authorizer information and will not be successful",
@@ -114,10 +114,10 @@ func TestWebhookEval(t *testing.T) {
 		authorizer: "multi authorizer2.yaml",
 		expected: k8s.EvalResponse{
 			WebhookMatchConditions: [][]*k8s.EvalResult{
-				{{Name: strptr("breakglass"), Result: false, Cost: uint64ptr(7)}},
+				{{Name: strptr("breakglass"), Result: false, Cost: uint64ptr(350006)}},
 				{{Name: strptr("exclude-bootcamp"), Result: false, Cost: uint64ptr(7)}},
 			},
-			Cost: uint64ptr(14),
+			Cost: uint64ptr(350013),
 		},
 	}, {
 		name:       "test multiple webhooks, match conditions will rely on request and authorizer information with mixed responses",
@@ -127,10 +127,10 @@ func TestWebhookEval(t *testing.T) {
 		authorizer: "multi authorizer3.yaml",
 		expected: k8s.EvalResponse{
 			WebhookMatchConditions: [][]*k8s.EvalResult{
-				{{Name: strptr("breakglass"), Result: false, Cost: uint64ptr(7)}},
+				{{Name: strptr("breakglass"), Result: false, Cost: uint64ptr(350006)}},
 				{{Name: strptr("exclude-leases"), Result: true, Cost: uint64ptr(5)}, {Name: strptr("exclude-kubelet-requests"), Result: true, Cost: uint64ptr(5)}},
 			},
-			Cost: uint64ptr(17),
+			Cost: uint64ptr(350016),
 		},
 	}}
 	for _, tt := range tests {


### PR DESCRIPTION
**Depends on #113** (the CEL-libraries PR, "k8s: match the apiserver base env's CEL library set") — both edit `k8s/cel.go`, so that one merges first; this branch carries its commit until it does.

## What this does

The k8s-mode CEL env (`k8s/cel.go`, shared by the vap and webhook modes) tracked cost with cel-go's defaults, so the cost shown for an expression did not match what a real cluster charges. This adds the cost accounting apiserver's `base.go` configures on the same env:

- `CostEstimatorOptions` / `CostTrackerOptions(PresenceTestHasCost(false))` — keeps `has()` at 0, as cel-go did before 0.17.7.
- `CostTracking(&library.CostEstimator{})` — apiserver's own estimator, which prices the extended-library functions (`ip`, `cidr`, `url`, `semver`, …) and, most visibly, an authorizer `check()` at a flat **350000**. The playground was charging ~10 for a check; a real cluster charges 350000 (apiserver's comment: *"set to allow for only two authorization checks per expression"*).

## Honest scope: closer parity, not exact

I verified the result against the real apiserver stack, and want to be precise about what this achieves:

- **Exact** for the authorizer and URL functions: a webhook `check()` is **350006** here and on a real apiserver, confirmed (350000 for the check itself plus 6 for the rest of the expression).
- **Still slightly under** for expressions using `variables.*`, string concatenation, or `in` over a typed list. Example: the vap authz validation shows **350009** where a real cluster charges **350010**.

The residual gap is **pre-existing and structural**: the playground *parses* expressions (flat activation, no type-checking) where the apiserver *compiles* and type-checks them, so a `variables.x` access costs 1 here vs 2 there. This PR does not change that — fixing it would mean changing how the playground evaluates, which is a much larger, separate thing. So this closes the big gap (authorizer checks were undercharged by roughly 35,000×, and `url()` was underpriced) and leaves the small structural ones documented.

## Scope: cost accounting only

This changes what existing vap/webhook users *see* — costs move, some dramatically — a different kind of change, with a different risk profile, from a purely-additive one, so it is worth reviewing on its own. The functions it reprices (`has()`, `url()`, `check()`) all predate the CEL-library additions; this is a pre-existing-fidelity fix, not a consequence of them. It shares a file (`k8s/cel.go`) with the CEL-libraries PR, which is the only reason it is stacked on top of it.

## Fixtures

The k8s tests assert exact cost values in fixtures under `k8s/testdata/`. The new expected numbers below were derived from apiserver's `cost.go` rather than copied from the test output — so they check the implementation, not just echo it:

- vap authorizer checks: validation `10 → 350009`
- vap url query: variable `14 → 19`
- webhook authorizer matchConditions: `7 → 350006`

## A follow-up worth filing

The raw `350000` reads as "is this broken?" without context. A good follow-up (UI-layer, not this PR) is to show the cost against the budget it spends from — the runtime budget is 10,000,000, and each authorizer `check()` costs 350,000, which is the lesson. The output panel's cost already links to the k8s docs on CEL resource constraints; this would make the number teach on its own.

## Verification

```
gofmt -l .          -> empty
go test ./... -race -> ok (eval, k8s)
```

Every changed cost was independently confirmed against apiserver's `cost.go` and a harness running the real apiserver compiler.

Written with AI assistance (Claude). I have read it, tested it, and I will be replying to review comments here myself — you won't be talking to a model.
