### PR TITLE
k8s: decode object input the way a cluster does

### DIFF
--- a/k8s/decode.go
+++ b/k8s/decode.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Undistro Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import (
+	"strings"
+
+	apimachineryjson "k8s.io/apimachinery/pkg/util/json"
+	sigsyaml "sigs.k8s.io/yaml"
+)
+
+// decodeObjectInput parses user-supplied resource YAML (the object/oldObject
+// tabs) into the map[string]any the CEL activation binds, reproducing exactly
+// what a real cluster does to the document before admission control ever sees
+// it. kubectl converts YAML to JSON client-side with
+// sigs.k8s.io/yaml.YAMLToJSON -- which is YAML 1.1, so bare `on`/`off`/`yes`/`no`
+// keys and values coerce to booleans (and, because `on` and `yes` both become
+// the key `true`, one such annotation is silently dropped, just as a cluster
+// drops it). The apiserver then decodes that JSON with apimachinery's util/json,
+// which keeps integral numbers as int64 rather than float64, so CEL sees them as
+// `int` and integer arithmetic, `%` and `type(x) == int` behave as they do on a
+// cluster. An empty or whitespace-only input yields a nil map, mirroring an
+// empty editor tab in the playground UI.
+//
+// The map, vap and webhook modes share this decoder so that every mode shows
+// what a cluster would do with the same document.
+func decodeObjectInput(input []byte) (map[string]any, error) {
+	if len(strings.TrimSpace(string(input))) == 0 {
+		return nil, nil
+	}
+	jsonBytes, err := sigsyaml.YAMLToJSON(input)
+	if err != nil {
+		return nil, err
+	}
+	var decoded map[string]any
+	if err := apimachineryjson.Unmarshal(jsonBytes, &decoded); err != nil {
+		return nil, err
+	}
+	return decoded, nil
+}

--- a/k8s/decode.go
+++ b/k8s/decode.go
@@ -34,8 +34,8 @@ import (
 // cluster. An empty or whitespace-only input yields a nil map, mirroring an
 // empty editor tab in the playground UI.
 //
-// The map, vap and webhook modes share this decoder so that every mode shows
-// what a cluster would do with the same document.
+// The vap and webhook modes share this decoder so that both modes show what a
+// cluster would do with the same document.
 func decodeObjectInput(input []byte) (map[string]any, error) {
 	if len(strings.TrimSpace(string(input))) == 0 {
 		return nil, nil

--- a/k8s/decode_test.go
+++ b/k8s/decode_test.go
@@ -1,0 +1,52 @@
+// Copyright 2023 Undistro Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s
+
+import "testing"
+
+func TestDecodeObjectInputIsClusterFaithful(t *testing.T) {
+	input := []byte(`
+metadata:
+  annotations:
+    on: keepme
+enabled: yes
+replicas: 5
+`)
+	decoded, err := decodeObjectInput(input)
+	if err != nil {
+		t.Fatalf("decodeObjectInput() error: %v", err)
+	}
+
+	annotations := decoded["metadata"].(map[string]any)["annotations"].(map[string]any)
+	// The bare key `on` is coerced to the boolean key `true`, exactly as a
+	// cluster does; yaml.v3 would have preserved the string key "on".
+	if _, ok := annotations["on"]; ok {
+		t.Errorf(`annotation key "on" survived as a string; want it coerced to "true"`)
+	}
+	if got, ok := annotations["true"]; !ok || got != "keepme" {
+		t.Errorf(`annotations["true"] = %v (present=%v), want "keepme"`, got, ok)
+	}
+
+	// The bare value `yes` is coerced to a bool, not kept as the string "yes".
+	if got := decoded["enabled"]; got != true {
+		t.Errorf(`decoded["enabled"] = %#v (%T), want bool true`, got, got)
+	}
+
+	// Integral numbers stay int64 (CEL int), not float64, so integer
+	// arithmetic and `%` keep working as they do on a cluster.
+	if got := decoded["replicas"]; got != int64(5) {
+		t.Errorf(`decoded["replicas"] = %#v (%T), want int64(5)`, got, got)
+	}
+}

--- a/k8s/testdata/vap/decode1 policy.yaml
+++ b/k8s/testdata/vap/decode1 policy.yaml
@@ -1,0 +1,20 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: "cluster-faithful-decode"
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups:   ["example.com"]
+      apiVersions: ["v1"]
+      operations:  ["CREATE", "UPDATE"]
+      resources:   ["caches"]
+  validations:
+    # `eviction: on` is YAML 1.1, so a cluster stores a boolean here, not the
+    # string "on".
+    - expression: "object.spec.eviction == true"
+      message: "eviction must be enabled"
+    # Integral numbers reach CEL as int, not double, so `%` has an overload.
+    - expression: "object.spec.replicas % 2 == 1"
+      message: "replicas must be odd"

--- a/k8s/testdata/vap/decode1 updated.yaml
+++ b/k8s/testdata/vap/decode1 updated.yaml
@@ -1,0 +1,8 @@
+apiVersion: example.com/v1
+kind: Cache
+metadata:
+  name: sessions
+  namespace: default
+spec:
+  eviction: on
+  replicas: 3

--- a/k8s/testdata/webhook/updated5.yaml
+++ b/k8s/testdata/webhook/updated5.yaml
@@ -1,0 +1,8 @@
+apiVersion: example.com/v1
+kind: Cache
+metadata:
+  name: sessions
+  namespace: default
+spec:
+  eviction: on
+  replicas: 3

--- a/k8s/testdata/webhook/webhook5.yaml
+++ b/k8s/testdata/webhook/webhook5.yaml
@@ -1,0 +1,25 @@
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingWebhookConfiguration
+webhooks:
+  - name: my-webhook.example.com
+    matchPolicy: Equivalent
+    rules:
+      - operations: ['CREATE','UPDATE']
+        apiGroups: ['*']
+        apiVersions: ['*']
+        resources: ['*']
+    failurePolicy: 'Ignore'
+    sideEffects: None
+    clientConfig:
+      service:
+        namespace: my-namespace
+        name: my-webhook
+      caBundle: 'PGNhYnVuZGxlPgo='
+    matchConditions:
+      # `eviction: on` is YAML 1.1, so a cluster stores a boolean here, not the
+      # string "on".
+      - name: 'eviction-enabled'
+        expression: 'object.spec.eviction == true'
+      # Integral numbers reach CEL as int, not double, so `%` has an overload.
+      - name: 'odd-replicas'
+        expression: 'object.spec.replicas % 2 == 1'

--- a/k8s/validatingadmissionpolicy.go
+++ b/k8s/validatingadmissionpolicy.go
@@ -88,13 +88,13 @@ func EvalValidatingAdmissionPolicy(policyInput, oldObjectInput, objectValueInput
 		return "", err
 	}
 
-	var oldObjectValue map[string]any
-	if err := yaml.Unmarshal(oldObjectInput, &oldObjectValue); err != nil {
+	oldObjectValue, err := decodeObjectInput(oldObjectInput)
+	if err != nil {
 		return "", fmt.Errorf("failed to decode input for the old resource value: %w", err)
 	}
 
-	var objectValue map[string]any
-	if err := yaml.Unmarshal(objectValueInput, &objectValue); err != nil {
+	objectValue, err := decodeObjectInput(objectValueInput)
+	if err != nil {
 		return "", fmt.Errorf("failed to decode input for the new resource value: %w", err)
 	}
 

--- a/k8s/validatingadmissionpolicy_test.go
+++ b/k8s/validatingadmissionpolicy_test.go
@@ -379,6 +379,23 @@ func TestValidationEval(t *testing.T) {
 			}},
 			Cost: uint64ptr(107),
 		},
+	}, {
+		// The object is decoded the way a cluster decodes it. `eviction: on` is
+		// YAML 1.1, so it reaches CEL as a bool rather than the string "on" --
+		// the first validation fails without that coercion. The second guards
+		// the other half of the decoder: `replicas: 3` must reach CEL as an int
+		// rather than a double, or `%` has no overload.
+		name:    "test an object whose values depend on a cluster-faithful decode",
+		policy:  "decode1 policy.yaml",
+		orig:    "",
+		updated: "decode1 updated.yaml",
+		expected: k8s.EvalResponse{
+			Validations: []*k8s.EvalResult{
+				{Result: true, Cost: uint64ptr(4)},
+				{Result: true, Cost: uint64ptr(5)},
+			},
+			Cost: uint64ptr(9),
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/k8s/webhook.go
+++ b/k8s/webhook.go
@@ -29,13 +29,13 @@ func EvalWebhook(webhookInput, oldObjectInput, objectValueInput, requestInput, a
 		return "", err
 	}
 
-	var oldObjectValue map[string]any
-	if err := yaml.Unmarshal(oldObjectInput, &oldObjectValue); err != nil {
+	oldObjectValue, err := decodeObjectInput(oldObjectInput)
+	if err != nil {
 		return "", fmt.Errorf("failed to decode input for the old object resource value: %w", err)
 	}
 
-	var objectValue map[string]any
-	if err := yaml.Unmarshal(objectValueInput, &objectValue); err != nil {
+	objectValue, err := decodeObjectInput(objectValueInput)
+	if err != nil {
 		return "", fmt.Errorf("failed to decode input for the object resource value: %w", err)
 	}
 

--- a/k8s/webhook_test.go
+++ b/k8s/webhook_test.go
@@ -132,6 +132,22 @@ func TestWebhookEval(t *testing.T) {
 			},
 			Cost: uint64ptr(17),
 		},
+	}, {
+		// The object is decoded the way a cluster decodes it. `eviction: on` is
+		// YAML 1.1, so it reaches CEL as a bool rather than the string "on" --
+		// the first match condition fails without that coercion. The second
+		// guards the other half of the decoder: `replicas: 3` must reach CEL as
+		// an int rather than a double, or `%` has no overload.
+		name:    "test a single webhook whose match conditions depend on a cluster-faithful decode",
+		webhook: "webhook5.yaml",
+		updated: "updated5.yaml",
+		expected: k8s.EvalResponse{
+			WebhookMatchConditions: [][]*k8s.EvalResult{{
+				{Name: strptr("eviction-enabled"), Result: true, Cost: uint64ptr(4)},
+				{Name: strptr("odd-replicas"), Result: true, Cost: uint64ptr(5)},
+			}},
+			Cost: uint64ptr(9),
+		},
 	}}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
## What

The `vap` (ValidatingAdmissionPolicy) and `webhooks` modes decode their
`object` / `oldObject` input with `gopkg.in/yaml.v3`, which is YAML 1.2. A real
cluster does not. This PR routes those four parses through a small shared helper
that reproduces the actual path a manifest takes into admission control:

1. `sigs.k8s.io/yaml.YAMLToJSON` — YAML 1.1, client-side, exactly what
   `kubectl apply` does to a manifest. Bare `on`/`off`/`yes`/`no` keys and
   values coerce to booleans, including the `on:` / `yes:` key collision that
   silently drops one of the two, just as a cluster drops it.
2. `k8s.io/apimachinery/pkg/util/json.Unmarshal` — keeps integral numbers as
   `int64` (CEL `int`) rather than `float64`, so `%`, integer arithmetic and
   `type(x) == int` behave the way they do on a cluster.

Two commits: the helper (`k8s/decode.go`), then the switch of the two modes onto
it.

## Why

The playground's value is that it tells you what your policy will do in a real
cluster. Today it can disagree with one, for the same document:

```yaml
# object tab
spec:
  eviction: on
  replicas: 3
```

Under `yaml.v3`, `eviction` reaches CEL as the string `"on"`, so
`object.spec.eviction == true` is false — but on a cluster kubectl has already
turned it into a boolean and the same expression is true. Likewise `replicas`
arrives as a `double`, so `object.spec.replicas % 2 == 1` fails with
`no such overload: _%_` in the playground while working fine in a cluster.

Both are states no cluster ever stores. Someone debugging a policy against the
playground gets an answer that will not reproduce.

## Scope: what is deliberately *not* changed

Only the `object` and `oldObject` tabs move. They are the admission request's
resource documents — the things kubectl converts and the apiserver decodes.

The `request`, `namespace` and `authorizer` tabs stay on `yaml.v3`. Those are
not resource documents; they are parsed into the playground's own typed structs
(`AdmissionRequest`, `NamespaceType`, `Authorizer`) that model apiserver
context. Nothing about YAML 1.1 coercion is more faithful there, and switching
them would mean adding `json:` struct tags to shared types for no behavioural
gain. The `cel` mode's `dataInput` is likewise untouched — it is an arbitrary
document, not a Kubernetes resource.

So after this PR `yaml.v3` is still imported and used in both files, on purpose.

## Behaviour change for existing users

This is a user-visible change to two shipped modes, so it is worth being
explicit:

- Bare `on`/`off`/`yes`/`no` as a **map key** or a **scalar value** in
  object/oldObject now coerces to a boolean. An `on:` key and a `yes:` key in
  the same map now collapse into a single `true` key, one of them dropped —
  matching the cluster, differing from today's two-string-keys behaviour.
- Scalars that were previously the strings `"yes"` / `"no"` / `"on"` / `"off"`
  are now booleans, so an expression like `object.spec.enabled == true` can
  start matching where it previously did not.

Integral numbers were already `int64` under both decoders, so no CEL cost moves.
That was verified across the suite rather than assumed: every existing exact-cost
fixture in `k8s/validatingadmissionpolicy_test.go` and `k8s/webhook_test.go`
passes unchanged.

I also checked the existing fixtures in `k8s/testdata/vap/` and
`k8s/testdata/webhook/` for values whose meaning shifts under the new decoder —
there are none, so no fixture needed re-deriving.

## Tests

Two cases added, one per mode, in the existing table-driven style:

- `TestValidationEval` — "test an object whose values depend on a
  cluster-faithful decode"
- `TestWebhookEval` — "test a single webhook whose match conditions depend on a
  cluster-faithful decode"

Each evaluates an object with `eviction: on` and `replicas: 3` against two
expressions, one per half of the decoder: `object.spec.eviction == true`
(YAML 1.1 coercion) and `object.spec.replicas % 2 == 1` (int, not double).

`go test -race ./...`, `gofmt -l .`, `go vet ./...` and `make checklicense` are
all clean.
