### PR TITLE
web: stop the error colour leaking into later output

### DIFF
--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -374,6 +374,7 @@ a {
 
 .editor__output-holder .editor__output {
   background: #1d1f21;
+  color: #ffffff;
   resize: none;
   height: 100%;
   padding: 12px;
@@ -381,8 +382,12 @@ a {
   width: 100%;
 }
 
-.editor > .editor__output::placeholder {
+.editor__output-holder .editor__output::placeholder {
   color: #e1e7ea;
+}
+
+.editor__output-holder .editor__output.editor__output--error {
+  color: #e01e5a;
 }
 
 /* Buttons and Inputs */

--- a/web/assets/js/components/modals/playground-mode.js
+++ b/web/assets/js/components/modals/playground-mode.js
@@ -28,6 +28,7 @@ import { hideAccordions } from "../accordions/result.js";
 import { renderSharedContent } from "../../share.js";
 import { getCurrentMode } from "../../utils/localStorage.js";
 import { getDecompressedContent } from "../../utils/compress.js";
+import { clearOutput } from "../../utils/render-functions.js";
 
 const playgroundModesModalEl = document.getElementById(
   "playground-modes__modal"
@@ -127,7 +128,7 @@ async function handleModeClick(event, mode, element) {
   await renderUIChangesByMode(mode);
   localStorage.setItem(localStorageModeKey, value);
   hideAccordions();
-  output.value = "";
+  clearOutput();
   deleteContentUrlParam();
   setTimeout(() => modal.hide(), 350);
 }

--- a/web/assets/js/main.js
+++ b/web/assets/js/main.js
@@ -14,7 +14,11 @@
  * limitations under the License.
  */
 
-import { setCost } from "./utils/render-functions.js";
+import {
+  clearOutput,
+  setCost,
+  setOutputError,
+} from "./utils/render-functions.js";
 import {
   handleRenderAccordions,
   hideAccordions,
@@ -37,6 +41,7 @@ const output = document.getElementById("output");
 
 function run() {
   const values = getRunValues();
+  clearOutput();
   output.value = "Evaluating...";
   setCost("");
 
@@ -45,8 +50,7 @@ function run() {
     const result = eval(modeId, values);
     const { output: resultOutput, isError } = result;
     if (isError) {
-      output.value = resultOutput;
-      output.style.color = "red";
+      setOutputError(resultOutput);
       hideAccordions();
     } else {
       const obj = JSON.parse(resultOutput);
@@ -55,14 +59,13 @@ function run() {
 
       if ("result" in obj) {
         output.value = JSON.stringify(obj.result);
-        output.style.color = "white";
       } else {
         handleRenderAccordions(obj);
       }
       setCost(resultCost);
     }
   } catch (error) {
-    output.value = "";
+    clearOutput();
     setCost("");
     console.log(error);
   }

--- a/web/assets/js/utils/render-functions.js
+++ b/web/assets/js/utils/render-functions.js
@@ -86,7 +86,7 @@ export function renderExamplesInSelectInstance(mode, examples) {
           setEditorTheme(inputEditor);
         });
       hideAccordions();
-      output.value = "";
+      clearOutput();
     } else {
       if (!example) return;
       handleFillExpressionContent(mode, example);
@@ -94,9 +94,23 @@ export function renderExamplesInSelectInstance(mode, examples) {
     }
 
     setCost("");
-    output.value = "";
+    clearOutput();
     hideAccordions();
   });
+}
+
+// Paired so the error state is always set and cleared together, and the class
+// name lives in one place.
+export function clearOutput() {
+  const output = document.getElementById("output");
+  output.value = "";
+  output.classList.remove("editor__output--error");
+}
+
+export function setOutputError(text) {
+  const output = document.getElementById("output");
+  output.value = text;
+  output.classList.add("editor__output--error");
 }
 
 export function setCost(cost) {


### PR DESCRIPTION
Once any evaluation fails, the output panel stays red — for the rest of the session, across mode switches and successful runs. Nothing has gone wrong any more; the panel just keeps saying it has.

An error renders correctly:
<img width="1919" height="1065" alt="An evaluation error, correctly shown in red" src="https://github.com/user-attachments/assets/593cdd68-f014-48c9-b3f3-3038e88f9065" />


Switch to another example and the placeholder is still red:
<img width="1919" height="1065" alt="The placeholder still red after the error" src="https://github.com/user-attachments/assets/5bcbfe37-2461-4410-99cd-f32f30991457" />


## Why it sticks

The colour is set as an inline style on the textarea, and cleared on only one of the paths that replace the output. Inside `run()`:

```js
if (isError) {
  output.style.color = "red";          // set here
} else {
  if ("result" in obj) {
    output.style.color = "white";      // cleared only for the cel mode
  } else {
    handleRenderAccordions(obj);       // vap / webhooks: never cleared
  }
}
```

But `run()` is not the only thing that resets the output. Three other places blank it — the `catch` branch, the example-change handler in `render-functions.js`, and the mode switch in `playground-mode.js` — and none of them touched the colour. Switching example or mode after an error does not call `run()` at all, which is why the placeholder came back red.

## Why the placeholder, and not just the text

There is an older bug underneath, which is what makes the symptom show up on the placeholder specifically:

```css
.editor > .editor__output::placeholder { color: #e1e7ea; }
```

That is a direct-child selector, but the textarea is not a direct child of `.editor` — the ancestry is `.editor` → `.editor__output-holder` → `textarea`. The rule has never matched anything. With no `::placeholder` colour of its own, the browser derives one from the element's `color`, which is exactly the value left behind by the error.

Fixing only the first bug would have hidden this one rather than fixed it, so both are here.

## The fix

Drive the colour from a class rather than an inline style, and put the reset where the output is cleared — one `clearOutput()` in `render-functions.js`, used by all four sites that reset the output, `run()` included. The class is now added in exactly one place and removed in exactly one place, and no bare `output.value = ""` survives outside the helper, so a new reset site cannot forget.

Then scope the error colour to the content and leave the placeholder alone. That is correct on its own terms — the placeholder is instructional text, never an error — and it means a stale error class cannot show through an empty field, which is precisely where this was visible. So the two halves are independent: either would fix the report, and together a future missed reset degrades to invisible rather than to a red placeholder.

In the stylesheet: give the textarea an explicit `color` so it stops depending on JS having set one, and repair the `::placeholder` selector so it matches the element it was written for.

The error colour becomes `#e01e5a`, the red the result panel already uses for error text and icons, rather than the CSS keyword `red` — the declaration was moving into the stylesheet anyway and matching the existing palette seemed better than carrying a one-off. The normal text colour is `#ffffff`, which is what the JS was already setting.

This is the plain output textarea, which the CEL Expression mode writes into and which shows evaluation errors for every mode. The result accordions are a separate element and are unaffected.

## Testing

<!-- TODO(kim): confirm before opening. -->

Checked by hand against `make serve`, exercising each path that resets the output: trigger an evaluation error and confirm it is red; switch to another example *without* running and confirm it is no longer red; run that example and confirm the accordions render normally; switch to a blank example and confirm the placeholder is back to its normal grey; and switch mode from the Modes dialog straight after an error.

JavaScript and CSS only — no Go, and no wasm rebuild needed.

Written with AI assistance (Claude). I have read it, tested it, and I will be replying to review comments here myself — you won't be talking to a model. The commits are authored by me for the same reason.
