### PR TITLE
web: show what an empty result is, and keep newlines in result bodies

### DIFF
--- a/web/assets/css/accordions.css
+++ b/web/assets/css/accordions.css
@@ -69,10 +69,18 @@
   transition: transform 300ms;
 }
 
+/* Muted: this is the panel talking, not a value. */
+.editor__output-result-accordion .result-empty {
+  color: #7f8c98;
+  font-style: italic;
+}
+
+/* Some result bodies contain newlines without being wrapped in a <pre>. */
 .editor__output-result-accordion .result-accordion-expansible-content {
   transition: max-height 400ms, visibility 50ms;
   overflow-x: auto;
   overflow-y: hidden;
+  white-space: pre-wrap;
 }
 
 .editor__output-result-accordion[data-open="false"]

--- a/web/assets/js/components/accordions/result.js
+++ b/web/assets/js/components/accordions/result.js
@@ -56,18 +56,32 @@ function createAccordionItemsByResults(name, result, index) {
 
   outputResultEl.appendChild(listItem);
 }
+// An expression can legitimately produce nothing to print, and an open section
+// with an empty body reads as a broken panel rather than as a result. The two
+// ways of producing nothing stay separate placeholders: optional.none() and an
+// expression returning "" are different outcomes.
+function renderText(value) {
+  const text = escapeHtml(value);
+  if (text === "") return `<span class="result-empty">(empty string)</span>`;
+  return text;
+}
+
 function getResultValue(result) {
   if (result.isError) {
     return `<span style="color:#e01e5a">${escapeHtml(result.error)}</span>`;
   } else if ("message" in result) {
-    return escapeHtml(result.message);
+    return renderText(result.message);
   } else if ("value" in result) {
     if (typeof result.value === "object")
       return `<pre>${escapeHtml(JSON.stringify(result.value, null, 2))}</pre>`;
-    return escapeHtml(result.value);
+    return renderText(result.value);
   }
 
-  return escapeHtml(result.result);
+  // omitempty drops the key entirely when the expression yielded nothing.
+  if (result.result === undefined) {
+    return `<span class="result-empty">(no value)</span>`;
+  }
+  return renderText(result.result);
 }
 
 function createLabel(item, name, i) {


### PR DESCRIPTION
Two rendering faults in the result panel, both reachable from ordinary policies: sections that show nothing useful, and multi-line values that lose their line breaks.

## A section with nothing to show renders "undefined", or renders nothing at all

`getResultValue` ends with `return escapeHtml(result.result)`. When the evaluator omits `result` entirely, that is `String(undefined)` — the five-character string `"undefined"` — and the panel shows it as the section's body.

The key is omitted whenever an expression yields an optional with no value. One way to hit it is skipping an audit annotation:

```yaml
auditAnnotations:
- key: missing
  valueExpression: "optional.none()"
```

which evaluates to `{"name":"missing","cost":1}`. Audit annotations carry their value in `message` rather than `result` — `validatingadmissionpolicy.go` builds them with a nil `val` — and `getResults` returns nil for an optional with no value, so `omitempty` drops `message` too. No branch matches, and the fallthrough reads `result.result`. An optional chain that misses (`object.?metadata.?nope`) reaches it the same way.

So an expression says "emit nothing here" and the playground answers **undefined** — a JavaScript primitive with no meaning in CEL, which also reads as a failure when the policy did exactly what it was written to do.

An expression that returns `""` goes wrong the other way. `omitempty` keeps the key, because it only drops a nil interface and an empty string is not one. All three bare-text branches are affected — `message`, `value` and the `result` fallthrough — and each renders an empty body. An open section with nothing in it reads as a broken panel just as much as `undefined` does.

Four audit annotations in one run, before:
<img width="1919" height="1065" alt="Four expanded sections: three with empty bodies, one reading &quot;undefined&quot;" src="https://github.com/user-attachments/assets/c2fa92c8-9f11-47d7-91e9-1bc759094fdc" />


Each of the two gets its own placeholder. Keeping them separate matters: producing nothing and producing an empty string are different outcomes, and one placeholder for both would hide which happened.
<img width="1919" height="1065" alt="The same policy, after: &quot;(empty string)&quot; and &quot;(no value)&quot;" src="https://github.com/user-attachments/assets/a500989b-5aa7-44fa-a7e5-735cb5546475" />


The first two sections, `"\n"` and `" "`, are still blank, and that is where this stops. A value can render to nothing visible in more ways than two, and covering them all means deciding how to *display* whitespace — how much of it, and in what notation — which is a larger question than this fix. `(no value)` and `(empty string)` handle the cases that come up in a policy; the rest can wait until someone hits one. (The `"\n"` box is taller in the after shot: `pre-wrap` now renders that newline as a blank line.)

## Multi-line values are displayed with their newlines collapsed

Only the object branch of `getResultValue` wraps its body in a `<pre>`. A `message`, a scalar `value` and an error all return bare text into `innerHTML`, where ordinary HTML whitespace handling turns newlines into spaces.

```
{"result":false,"cost":13,"message":"Deployment nginx has 3 replicas.\nMaximum allowed is 1.\nSet spec.replicas to 1 or fewer."}
```

is three lines of advice, and the panel prints them as one:
<img width="1919" height="1065" alt="A three-line message rendered as a single run-on line" src="https://github.com/user-attachments/assets/ccd9d450-9762-4391-9957-9e0457a82a56" />


Errors are the other common case, because a CEL error quotes the source expression verbatim — a multi-line `expression:` block in YAML puts real newlines *and* their continuation indent into the error text, and both are lost.

The fix is `white-space: pre-wrap` on the body container:
<img width="1919" height="1065" alt="The same message rendered on three lines" src="https://github.com/user-attachments/assets/dbf63c7a-d4f6-433b-a0eb-280cea0d3699" />


`pre-wrap` rather than wrapping the bodies in a `<pre>`, because `<pre>` brings `white-space: pre`, which preserves newlines but does not wrap — a long message would run off the right edge behind a horizontal scrollbar — along with a monospace font and UA margins that are wrong for prose. `pre-wrap` preserves and wraps, and leaves the font alone.

It is set on the container rather than per-branch because `white-space` inherits, so one declaration covers every body type and any future one. The `<pre>` bodies are unaffected: their `white-space: pre` is declared by the UA stylesheet on the element itself, and a declaration always beats an inherited value. The bodies are built as HTML strings with no incidental indentation, so nothing else shifts.

Both affect the Validating Admission Policy and Web Hooks modes, the two that render result sections. The CEL Expression mode writes into the plain output textarea and is untouched.

Neither is new: `git log -S` puts the fallthrough in `23df193`, April 2024. I hit them while prototyping a copy button for the same panel locally — that path builds the section text independently, and where the two disagreed is where the rendering was wrong. The copy button is not proposed here.

No issue preceded this. Both are small, self-evident once seen, and cheap to revert, so I went straight to a PR rather than opening an issue to describe a screenshot. Happy to file one if you would rather have the paper trail.

## What this deliberately does not do

`getResultValue` has other rough edges — an object-valued `result` renders as `[object Object]`, and the error branch carries an inline colour that belongs in the stylesheet. Both are real, neither is this bug, and folding them in would turn a small fix into a rewrite of the renderer.

A `null` value is also left alone, deliberately. It renders as the literal `null`, which is what it is — a value, not an absence — so it is neither of the cases above.

Written with AI assistance (Claude); I have read and tested it, and I will be handling review comments myself.
