### PR TITLE
web: add a copy button to each result section

### DIFF
--- a/web/assets/css/accordions.css
+++ b/web/assets/css/accordions.css
@@ -69,10 +69,18 @@
   transition: transform 300ms;
 }
 
+/* Muted: this is the panel talking, not a value. */
+.editor__output-result-accordion .result-empty {
+  color: #7f8c98;
+  font-style: italic;
+}
+
+/* Some result bodies contain newlines without being wrapped in a <pre>. */
 .editor__output-result-accordion .result-accordion-expansible-content {
   transition: max-height 400ms, visibility 50ms;
   overflow-x: auto;
   overflow-y: hidden;
+  white-space: pre-wrap;
 }
 
 .editor__output-result-accordion[data-open="false"]

--- a/web/assets/css/accordions.css
+++ b/web/assets/css/accordions.css
@@ -69,6 +69,76 @@
   transition: transform 300ms;
 }
 
+/* The caret, the status icons and the label text, left-aligned as one row. */
+.editor__output-result-accordion .result-accordion-label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  position: relative;
+}
+
+.editor__output-result-accordion .result-accordion-error-icon {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #e01e5a;
+}
+
+.editor__output-result-accordion .result-error {
+  color: #e01e5a;
+}
+
+/* The cost and the copy button, right-aligned opposite the label. */
+.editor__output-result-accordion .result-accordion-actions {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  flex-shrink: 0;
+}
+
+/* 24px square: the collapsed row is a 24px content box, so this is the largest
+   the button can be without making the row overflow its rounded card. The hit
+   area is extended past that by the ::after below. */
+.editor__output-result-accordion .result-accordion-copy {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 24px;
+  height: 24px;
+  padding: 0;
+  border: none;
+  border-radius: 4px;
+  background: none;
+  cursor: pointer;
+  color: #7f8c98;
+  font-size: 1.15rem;
+  line-height: 1;
+  transition: color 150ms, background-color 150ms;
+}
+
+/* Widens the clickable region to 40x40 without taking up any layout space, so
+   the button stays easy to hit inside a row that cannot grow. */
+.editor__output-result-accordion .result-accordion-copy::after {
+  content: "";
+  position: absolute;
+  inset: -8px;
+}
+
+.editor__output-result-accordion .result-accordion-copy:hover,
+.editor__output-result-accordion .result-accordion-copy:focus-visible {
+  color: #e6e6e6;
+  background-color: rgba(255, 255, 255, 0.12);
+}
+
+.editor__output-result-accordion .result-accordion-copy.copied {
+  color: #4ec9b0;
+}
+
+.editor__output-result-accordion .result-accordion-copy.copy-failed {
+  color: #e01e5a;
+}
+
 /* Muted: this is the panel talking, not a value. */
 .editor__output-result-accordion .result-empty {
   color: #7f8c98;

--- a/web/assets/js/components/accordions/result.js
+++ b/web/assets/js/components/accordions/result.js
@@ -15,6 +15,10 @@
  */
 
 import { createTooltip } from "../tooltips/index.js";
+import {
+  COPY_FEEDBACK_MS,
+  copyToClipboard,
+} from "../../utils/clipboard.js";
 
 const outputResultEl = document.getElementById("editor__output-result");
 const holderEl = document.querySelector(".editor__output-holder");
@@ -30,6 +34,59 @@ function escapeHtml(value) {
     .replaceAll(">", "&gt;");
 }
 
+// sectionLabel names a result section, for the row and for the copy button's
+// accessible name. item.name is a validation or variable name straight out of
+// the policy.
+function sectionLabel(item, name, i) {
+  return item.name ? `${name}.${item.name}` : `${name}[${i}]`;
+}
+
+// aria-label wins the accessible-name computation over title, so both have to
+// move together or the icon swap stays visual-only.
+function setCopyLabel(button, label) {
+  button.title = label;
+  button.setAttribute("aria-label", label);
+}
+
+function createCopyButton(text, label) {
+  const button = document.createElement("button");
+  button.type = "button";
+  button.className = "result-accordion-copy";
+
+  const icon = document.createElement("i");
+  icon.className = "ph ph-copy";
+  button.appendChild(icon);
+
+  // Every section renders one of these, so an undifferentiated "Copy to
+  // clipboard" repeated N times is not navigable.
+  const idleLabel = label ? `Copy ${label}` : "Copy to clipboard";
+  setCopyLabel(button, idleLabel);
+
+  let resetTimer;
+  const showFeedback = (copied) => {
+    icon.className = copied ? "ph ph-check" : "ph ph-x";
+    button.classList.toggle("copied", copied);
+    button.classList.toggle("copy-failed", !copied);
+    setCopyLabel(button, copied ? "Copied" : "Could not copy");
+
+    window.clearTimeout(resetTimer);
+    resetTimer = window.setTimeout(() => {
+      icon.className = "ph ph-copy";
+      button.classList.remove("copied", "copy-failed");
+      setCopyLabel(button, idleLabel);
+    }, COPY_FEEDBACK_MS);
+  };
+
+  button.onclick = (event) => {
+    // The whole row toggles the accordion, so copying must not also collapse
+    // the section the user is reading.
+    event.stopPropagation();
+    copyToClipboard(text).then(showFeedback);
+  };
+
+  return button;
+}
+
 function createAccordionItemsByResults(name, result, index) {
   const listItem = document.createElement("li");
   listItem.className = "editor__output-result-accordion";
@@ -43,68 +100,86 @@ function createAccordionItemsByResults(name, result, index) {
   const accordionContent = document.createElement("div");
   accordionContent.className = "result-accordion-content";
   accordionContent.appendChild(createLabel(result, name, index));
+  // The cost and the copy button share a right-hand group, so the label still
+  // sits opposite them under the row's space-between.
+  const actions = document.createElement("div");
+  actions.className = "result-accordion-actions";
   const costSpan = document.createElement("span");
   costSpan.innerHTML = `Cost: ${result?.cost ?? "-"}`;
-  accordionContent.appendChild(costSpan);
+  actions.appendChild(costSpan);
+  const { text, html } = renderResult(result);
+  if (text !== "") {
+    const label = sectionLabel(result, name, index);
+    actions.appendChild(createCopyButton(text, label));
+  }
+  accordionContent.appendChild(actions);
 
   const expansibleContent = document.createElement("div");
   expansibleContent.className = "result-accordion-expansible-content";
-  expansibleContent.innerHTML = `<span>${getResultValue(result)}</span>`;
+  expansibleContent.innerHTML = `<span>${html}</span>`;
 
   listItem.appendChild(accordionContent);
   listItem.appendChild(expansibleContent);
 
   outputResultEl.appendChild(listItem);
 }
-// An expression can legitimately produce nothing to print, and an open section
-// with an empty body reads as a broken panel rather than as a result. The two
-// ways of producing nothing stay separate placeholders: optional.none() and an
-// expression returning "" are different outcomes.
-function renderText(value) {
-  const text = escapeHtml(value);
-  if (text === "") return `<span class="result-empty">(empty string)</span>`;
-  return text;
-}
-
-function getResultValue(result) {
+// renderResult produces both forms of a section body from one branch structure:
+// the markup for the panel, and the plain text the copy button puts on the
+// clipboard. They cannot drift apart while they are built together.
+//
+// text is "" wherever the markup is a placeholder describing the value rather
+// than being it, and no copy button is offered for those.
+function renderResult(result) {
   if (result.isError) {
-    return `<span style="color:#e01e5a">${escapeHtml(result.error)}</span>`;
-  } else if ("message" in result) {
-    return renderText(result.message);
-  } else if ("value" in result) {
-    if (typeof result.value === "object")
-      return `<pre>${escapeHtml(JSON.stringify(result.value, null, 2))}</pre>`;
+    const text = result.error == null ? "" : String(result.error);
+    return {
+      text,
+      html: `<span class="result-error">${escapeHtml(text)}</span>`,
+    };
+  }
+  if ("message" in result) return renderText(result.message);
+  if ("value" in result) {
+    if (typeof result.value === "object") {
+      const text = JSON.stringify(result.value, null, 2);
+      return { text, html: `<pre>${escapeHtml(text)}</pre>` };
+    }
     return renderText(result.value);
   }
 
   // omitempty drops the key entirely when the expression yielded nothing.
   if (result.result === undefined) {
-    return `<span class="result-empty">(no value)</span>`;
+    return { text: "", html: `<span class="result-empty">(no value)</span>` };
   }
   return renderText(result.result);
 }
 
+// An expression can legitimately produce nothing to print, and an open section
+// with an empty body reads as a broken panel rather than as a result. The two
+// ways of producing nothing stay separate placeholders: optional.none() and an
+// expression returning "" are different outcomes.
+function renderText(value) {
+  const text = String(value);
+  if (text === "") {
+    return { text, html: `<span class="result-empty">(empty string)</span>` };
+  }
+  return { text, html: escapeHtml(text) };
+}
+
 function createLabel(item, name, i) {
   const parentContainer = document.createElement("div");
-  parentContainer.style =
-    "display: flex; align-items: center; gap: 0.5rem; position:relative";
+  parentContainer.className = "result-accordion-label";
 
   const arrowIcon = document.createElement("i");
   arrowIcon.className = "ph ph-caret-right ph-bold result-arrow";
 
   const span = document.createElement("span");
-  // item.name is a validation or variable name straight out of the policy.
-  span.innerHTML = escapeHtml(
-    item.name ? `${name}.${item.name}` : `${name}[${i}]`
-  );
+  span.innerHTML = escapeHtml(sectionLabel(item, name, i));
 
   parentContainer.appendChild(arrowIcon);
 
   if (item?.isError) {
     const errorIcon = document.createElement("i");
-    errorIcon.className = "ph ph-x-circle ph-fill";
-    errorIcon.style =
-      "color: #e01e5a; z-index:999999; display:flex;align-items:center;justify-content: center;";
+    errorIcon.className = "ph ph-x-circle ph-fill result-accordion-error-icon";
 
     const errorIconWithTooltip = createTooltip({
       contentText: "Validation compilation failed.",

--- a/web/assets/js/components/accordions/result.js
+++ b/web/assets/js/components/accordions/result.js
@@ -56,18 +56,32 @@ function createAccordionItemsByResults(name, result, index) {
 
   outputResultEl.appendChild(listItem);
 }
+// An expression can legitimately produce nothing to print, and an open section
+// with an empty body reads as a broken panel rather than as a result. The two
+// ways of producing nothing stay separate placeholders: optional.none() and an
+// expression returning "" are different outcomes.
+function renderText(value) {
+  const text = escapeHtml(value);
+  if (text === "") return `<span class="result-empty">(empty string)</span>`;
+  return text;
+}
+
 function getResultValue(result) {
   if (result.isError) {
     return `<span style="color:#e01e5a">${escapeHtml(result.error)}</span>`;
   } else if ("message" in result) {
-    return escapeHtml(result.message);
+    return renderText(result.message);
   } else if ("value" in result) {
     if (typeof result.value === "object")
       return `<pre>${escapeHtml(JSON.stringify(result.value, null, 2))}</pre>`;
-    return escapeHtml(result.value);
+    return renderText(result.value);
   }
 
-  return escapeHtml(result.result);
+  // omitempty drops the key entirely when the expression yielded nothing.
+  if (result.result === undefined) {
+    return `<span class="result-empty">(no value)</span>`;
+  }
+  return renderText(result.result);
 }
 
 function createLabel(item, name, i) {

--- a/web/assets/js/share.js
+++ b/web/assets/js/share.js
@@ -23,6 +23,7 @@ import {
   getRunValues,
 } from "./utils/editor.js";
 import { getCurrentMode, getCurrentTheme } from "./utils/localStorage.js";
+import { COPY_FEEDBACK_MS, copyToClipboard } from "./utils/clipboard.js";
 
 const shareButton = document.getElementById("share");
 shareButton.addEventListener("click", share);
@@ -95,15 +96,22 @@ celInput.addEventListener("mouseleave", () => {
   celCopyIcon.style.display = "none";
 });
 
-celCopyIcon.addEventListener("click", () => {
-  const exprEditorValue = getExprEditorValue();
-  navigator.clipboard.writeText(exprEditorValue).catch(console.error);
-  celCopyHover.style.display = "none";
-  celCopyClick.style.display = "flex";
-  setTimeout(() => {
-    celCopyClick.style.display = "none";
-  }, 1000);
-});
+// The two editor icons are the same affordance over different nodes: swap the
+// hover label for the "copied" one, then put it back.
+function wireEditorCopy(icon, hover, click, getValue) {
+  icon.addEventListener("click", () => {
+    copyToClipboard(getValue()).then((copied) => {
+      if (!copied) return;
+      hover.style.display = "none";
+      click.style.display = "flex";
+      setTimeout(() => {
+        click.style.display = "none";
+      }, COPY_FEEDBACK_MS);
+    });
+  });
+}
+
+wireEditorCopy(celCopyIcon, celCopyHover, celCopyClick, getExprEditorValue);
 
 celCopyIcon.addEventListener("mouseover", () => {
   celCopyHover.style.display = "flex";
@@ -126,15 +134,7 @@ dataInput.addEventListener("mouseleave", () => {
   dataCopyIcon.style.display = "none";
 });
 
-dataCopyIcon.addEventListener("click", () => {
-  const dataInputValue = getInputEditorValue();
-  navigator.clipboard.writeText(dataInputValue);
-  dataCopyHover.style.display = "none";
-  dataCopyClick.style.display = "flex";
-  setTimeout(() => {
-    dataCopyClick.style.display = "none";
-  }, 1000);
-});
+wireEditorCopy(dataCopyIcon, dataCopyHover, dataCopyClick, getInputEditorValue);
 
 dataCopyIcon.addEventListener("mouseover", () => {
   dataCopyHover.style.display = "flex";
@@ -149,14 +149,20 @@ copyButton.addEventListener("click", copy);
 
 function copy() {
   const copyText = document.querySelector(".share-url__input");
+  // The highlight is the affordance here, so it happens whether or not the
+  // write succeeds; only the confirmation waits.
   copyText.select();
   copyText.setSelectionRange(0, 99999);
-  navigator.clipboard.writeText(copyText.value);
-  window.getSelection().removeAllRanges();
 
-  const tooltip = document.querySelector(".share-url__tooltip");
-  tooltip.style.opacity = 1;
-  setTimeout(() => {
-    tooltip.style.opacity = 0;
-  }, 3000);
+  copyToClipboard(copyText.value).then((copied) => {
+    window.getSelection().removeAllRanges();
+    if (!copied) return;
+
+    const tooltip = document.querySelector(".share-url__tooltip");
+    tooltip.style.opacity = 1;
+    // Longer than the icon ticks: this one is a sentence to read, not a glyph.
+    setTimeout(() => {
+      tooltip.style.opacity = 0;
+    }, 3000);
+  });
 }

--- a/web/assets/js/utils/clipboard.js
+++ b/web/assets/js/utils/clipboard.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2024 Undistro Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+// document.execCommand is deprecated, but navigator.clipboard only exists in a
+// secure context, which the playground is not when reached over a LAN address
+// rather than localhost.
+function copyWithExecCommand(text) {
+  const textarea = document.createElement("textarea");
+  textarea.value = text;
+  textarea.setAttribute("readonly", "");
+  textarea.style.position = "fixed";
+  textarea.style.top = "-1000px";
+  textarea.style.opacity = "0";
+  // execCommand copies the *document* selection, so this clobbers whatever the
+  // user had selected and moves focus to the textarea. Both are put back below.
+  const previousFocus = document.activeElement;
+  const selection = window.getSelection();
+  const previousRanges = [];
+  for (let i = 0; i < selection.rangeCount; i++) {
+    previousRanges.push(selection.getRangeAt(i));
+  }
+
+  document.body.appendChild(textarea);
+  textarea.select();
+  textarea.setSelectionRange(0, text.length);
+
+  let copied = false;
+  try {
+    copied = document.execCommand("copy");
+  } catch (error) {
+    console.error("failed to copy to the clipboard", error);
+  }
+  document.body.removeChild(textarea);
+
+  selection.removeAllRanges();
+  previousRanges.forEach((range) => selection.addRange(range));
+  previousFocus?.focus?.();
+  return copied;
+}
+
+// How long a copy affordance stays in its "copied" state.
+export const COPY_FEEDBACK_MS = 1000;
+
+// Resolves to whether the text reached the clipboard, and never rejects:
+// callers decide what to show.
+export async function copyToClipboard(text) {
+  if (navigator.clipboard?.writeText) {
+    try {
+      await navigator.clipboard.writeText(text);
+      return true;
+    } catch (error) {
+      console.error("failed to copy to the clipboard", error);
+    }
+  }
+  return copyWithExecCommand(text);
+}


### PR DESCRIPTION
**Depends on #120** ("web: show what an empty result is, and keep newlines in result bodies") — it is the commit directly underneath this one, so this PR's diff shows both until that merges.

Every result section gets a copy button beside its cost. Click it and the section's text is on your clipboard; the icon flips to a tick for about a second.
<img width="1919" height="1065" alt="Copy buttons on the sections that have text, and none on the two placeholder rows" src="https://github.com/user-attachments/assets/62f4d254-eee6-42b4-a328-1d5741214101" />

Until now the only way to get a value out of the output panel was to select it by hand — awkward for the panel's most useful content, a multi-line JSON object or a validation message you want to paste into a policy, and fiddly besides, since clicking inside a section is close to clicking the row that collapses it.

The new buttons appear in the Validating Admission Policy and Web Hooks modes, the two that render result sections; the CEL Expression mode writes into the plain output textarea and gains nothing here. The change to the three existing copy buttons described below does reach every mode, since the editor icons are on every editor.

## Implementation notes

- The button stops click propagation, so copying does not collapse the section you are reading.
- Sections with no text get no button, rather than one that copies an empty string — the two placeholder rows above.
- A transparent `::after` widens the hit area to 40×40 around a button the row can only afford to make 24px. The row loses that patch as toggle area: a click up to 8px outside the button copies instead of collapsing.
- `navigator.clipboard` exists only in a secure context, so there is a `document.execCommand` fallback for the playground served over a LAN address. It restores the user's selection and focus afterwards, and if both paths fail the icon turns red rather than failing quietly. That shim is browser-compatibility plumbing rather than accordion rendering, so it lives in `utils/clipboard.js` — see below, it has other callers.
- `renderResult` produces the panel markup and the clipboard text together from one branch structure, so the two forms cannot drift apart. Building them as a pair is what surfaced the rendering faults in #120.
- `aria-label` and `title` move together, and each button is named after its section (`Copy validations[1]`), so the feedback reaches a screen reader and not just the pixels.

## The three existing copy buttons

`share.js` already had three clipboard call sites — the two editor icons and the share-URL dialog — and they now use the same helper. That was not a tidy-up for its own sake: all three showed their "Copied!" confirmation without waiting for `writeText` to resolve, so a failed copy still reported success, and two of the three had no `.catch` at all, making a rejection an unhandled promise error. Going through a helper that reports whether the write worked fixes that by construction.

What changes for a user: on failure those three now show nothing instead of a false confirmation. They have no failure affordance of their own — unlike the new buttons, which turn red — and inventing one for them belongs to whoever redesigns those icons. Silence is at least honest. On success nothing changes at all.

The two editor icons were the same nine-line handler twice over different nodes, so they collapse into one `wireEditorCopy` call each — `share.js` comes out shorter than it went in, despite gaining the fix. The share-URL tooltip keeps its 3000ms: it is a sentence to read, where the icons are a glyph that flips.

Three inline styles in `result.js` become classes along the way: the error text, the error icon and the label container. The row's other half — the cost and button group this PR adds — is class-styled, and the commit underneath moved a colour out of JS the same way, so leaving them would have made the two halves of one row inconsistent.

## Testing

<!-- TODO(kim): confirm this matches what you ran, and name the browser. -->

Exercised by hand against both modes: copied from a multi-line `<pre>` body, a single-line message and an errored section, and confirmed the accordion does not collapse on click, the tick reverts, and the clipboard matches what is rendered.

The three pre-existing buttons were re-checked too, since this changes them: both editor copy icons and the share-URL dialog still confirm and clear as before.

`http://localhost` is a secure context, so that only covers the `navigator.clipboard` path. The `execCommand` fallback is reasoned through but not exercised, and neither is the failure path — which is also the only way to see the one behaviour change to the existing buttons. A check from anyone serving the playground on a non-localhost address would be welcome.

JavaScript and CSS only — no Go, and no wasm rebuild needed.

Written with AI assistance (Claude); I have read and tested it, and I will be handling review comments myself.
