### PR TITLE
web: fix two scrolling faults in the result panel

### DIFF
--- a/web/assets/css/accordions.css
+++ b/web/assets/css/accordions.css
@@ -20,21 +20,22 @@
   flex-direction: column;
   gap: 1rem;
   position: absolute;
+  /* Not width/height: 100% -- that adds the padding on top and overflows
+     .editor__output-holder. */
   top: 0;
   left: 0;
+  right: 0;
   bottom: 0;
   margin: 0;
   padding-left: 1rem;
   padding-top: 1rem;
   padding-bottom: 1rem;
-  width: 100%;
-  height: 100%;
   background-color: #1d1f21;
   overflow-y: auto;
 }
 
 .editor__output-result .editor__output-result-accordion {
-  width: calc(100% - 4rem);
+  width: calc(100% - 3rem); /* 1rem of the gutter is the padding above */
   display: flex;
   flex-direction: column;
   gap: 10px;

--- a/web/assets/css/accordions.css
+++ b/web/assets/css/accordions.css
@@ -70,6 +70,7 @@
 }
 
 .editor__output-result-accordion .result-accordion-expansible-content {
+  --result-body-max-height: 450px;
   transition: max-height 400ms, visibility 50ms;
   overflow-x: auto;
   overflow-y: hidden;
@@ -83,10 +84,19 @@
 
 .editor__output-result-accordion[data-open="true"]
   .result-accordion-expansible-content {
-  max-height: 450px;
+  max-height: var(--result-body-max-height);
   visibility: visible;
 }
 
 .editor__output-result-accordion[data-open="true"] .result-arrow {
   transform: rotate(90deg);
+}
+
+/* Scrolls here rather than on .result-accordion-expansible-content, whose
+   overflow-y stays hidden so its opening transition cannot flash a scrollbar.
+   Matching caps and margin: 0 keep this box inside that clip. */
+.editor__output-result-accordion .result-accordion-expansible-content pre {
+  margin: 0;
+  max-height: var(--result-body-max-height);
+  overflow: auto;
 }

--- a/web/assets/css/styles.css
+++ b/web/assets/css/styles.css
@@ -368,11 +368,10 @@ a {
   position: relative;
   height: 100%;
   width: 100%;
-  /* overflow-y: auto;
-  overflow-x: hidden; */
 }
 
 .editor__output-holder .editor__output {
+  box-sizing: border-box;
   background: #1d1f21;
   resize: none;
   height: 100%;

--- a/web/assets/js/components/accordions/result.js
+++ b/web/assets/js/components/accordions/result.js
@@ -124,8 +124,6 @@ export function handleRenderAccordions(result) {
   outputResultEl.style.display = "flex";
 
   holderEl.scrollTo({ top: 0, behavior: "smooth" });
-  holderEl.style.overflowY = "auto";
-  holderEl.style.overflowX = "hidden";
 
   Object.entries(result).forEach(([key, values]) => {
     renderAccordions(key, values);


### PR DESCRIPTION
Two independent bugs, both reachable with an ordinary policy: a result body taller than the panel allows is clipped with no way to scroll it, and the panel's own scrollbar has a 32px range that comes from box overflow rather than from its contents, so its thumb sits at the top while the content is at the bottom.

Before. The output sections object body ends mid-JSON with nothing to scroll it, and the single thumb at the panel's edge is nearly as tall as its track — it belongs to a scroller with 32px of range, which is why it does not move as sections open.
<img width="1423" height="917" alt="The result panel before the fix" src="https://github.com/user-attachments/assets/e45b8164-98c5-4dc2-a7ec-b824dfbb7edf" />


After. The body scrolls to the end of the object on a bar of its own, and the thumb at the panel's edge is short and proportional, because it now belongs to the list and measures the sections in it.
<img width="1423" height="917" alt="The same panel after the fix" src="https://github.com/user-attachments/assets/4d786b8b-1a93-48c5-8598-c6fe982d7cd4" />


To reproduce both, load the **Variables in Validation** example and add a variable *and* a validation that reads it — variables are evaluated lazily and only reported once something references them (`k8s/evals.go:177`):

```yaml
  variables:
  - name: spec
    expression: "object.spec"
  validations:
  - expression: "has(variables.spec.replicas)"
```

`object.spec` on that example's Deployment pretty-prints to 42 JSON lines. Nothing shipped overflows on its own today — its two object-valued variables, `containers` and `containersToCheck`, come to 10 lines each.

## A tall body is clipped rather than scrolled

`.result-accordion-expansible-content` — the body of a section — is capped at 450px with `overflow-y: hidden`, so anything taller simply ends.

The body that reaches the cap is the `<pre>` built for an object-valued result, and only a `spec.variables` entry produces one: `EvalVariable` is the only struct with a `value` key, and only the Validating Admission Policy mode emits variables — the webhooks mode passes nil for all of them (`k8s/webhook.go:120`). Everything else arrives as `result` or `message` and takes a text branch. The CEL Expression mode never reaches the accordions at all, since its response always carries a top-level `result`.

The `<pre>` gets its own scroll box, taking the container's cap through a custom property rather than a second literal. The constraint is that the `<pre>`'s cap cannot exceed the container's, or the container clips the bottom of the `<pre>`'s own viewport and its last rows stay unreachable behind a scrollbar that scrolls past them; making the two equal is the choice that uses the whole cap.

`margin: 0` matters now that they are equal: the container is a block formatting context, so the UA stylesheet's 1em `<pre>` margins cannot collapse out of it and would push the `<pre>`'s bottom, and its horizontal scrollbar, past the clip. Bodies under the cap therefore render about 2em shorter than before — roughly 26px at the browser's monospace default — which is the change of consequence to sections that were never broken.

The scroll box is on the `<pre>` rather than on the container because the container's `overflow-y: hidden` is doing a job: `max-height` animates from 0 over 400ms while the body is already visible, so with `auto` there every section — including a three-line message — would raise a scrollbar for the length of the animation and then drop it.

## The panel's scrollbar range is box overflow, not content

Two boxes overflow the holder they sit in, because there is no global `box-sizing` reset and both are sized in percentages with their padding added outside: the result list, `width: 100%; height: 100%` with 1rem of padding on three sides, ends up 32px taller and 16px wider; the output textarea, which stays laid out underneath, does the same with its 12px padding and the UA border nothing here resets.

`result.js` sets `overflow-y: auto` on the holder inline and never clears it, so from the first accordion render on, the holder scrolls that overflow. Its range comes from a box rather than from content, so expanding sections does not change it and scrolling the list does not move it: the thumb stays at the top while the content is near the bottom, and dragging it moves the panel 32px and stops. The wheel hides it, since the pointer is over the list and scrolls the inner scroller, which does have the right range.

The list is inset on all four sides instead of sized, so its padding sits inside a box that exactly fills the holder. `box-sizing: border-box` does the same for the textarea, which keeps its height and padding, and absorbs the UA border along with them.

The cards go from `calc(100% - 4rem)` to `calc(100% - 3rem)` to keep the layout where it is: they are measured against the list's content width, which loses the 1rem left padding it used to be measured without, so the same subtraction would have narrowed every card by 16px and widened the right gutter to match.

With nothing overflowing it any more, the holder stops being a scroll container: the same commit drops the inline `overflow-y`/`overflow-x` `result.js` gave it, and the commented-out copy of the pair in the stylesheet. That makes this the one commit touching JavaScript — two deleted lines. It would be wanted again only if either box went back to being sized rather than fitted. The two `holderEl.scrollTo` calls are dead alongside it — both fire when the list is empty or hidden — and are left for a separate tidy-up.

## Deliberately left alone

- A text body can outgrow the cap too. Capping the `<span>` it lives in would work in the stylesheet alone, but that span also wraps the `<pre>`, so it would nest two scroll boxes; doing it properly means moving the cap onto the span, which is a larger rethink than this.
- The row's click handler is on the `<li>`, so clicking into a body — now a scrollable surface — collapses the section. It already behaved that way, and fixing it means a target check in `result.js` rather than a stylesheet rule. It also stops mattering much once #121 lands: each section gets a copy button there, so the text no longer has to be selected by hand.

## Testing

Both screenshots are the same policy at the same URL, from two builds differing only in these two stylesheets

Written with AI assistance (Claude); I have read and tested it, and I will be handling review comments myself.
