### PR TITLE
k8s: name the fields in the CelInformation literals

### DIFF
--- a/k8s/extractcelinfo.go
+++ b/k8s/extractcelinfo.go
@@ -132,7 +132,12 @@ func extractVAPV1Alpha1CelInformation(policy *v1alpha1.ValidatingAdmissionPolicy
 	}
 
 	return &CelInformation{
-		name, namespace, variables, validations, auditAnnotations, matchConditions, nil,
+		name:             name,
+		namespace:        namespace,
+		variables:        variables,
+		validations:      validations,
+		auditAnnotations: auditAnnotations,
+		matchConditions:  matchConditions,
 	}
 }
 
@@ -175,7 +180,12 @@ func extractVAPV1Beta1CelInformation(policy *v1beta1.ValidatingAdmissionPolicy) 
 	}
 
 	return &CelInformation{
-		name, namespace, variables, validations, auditAnnotations, matchConditions, nil,
+		name:             name,
+		namespace:        namespace,
+		variables:        variables,
+		validations:      validations,
+		auditAnnotations: auditAnnotations,
+		matchConditions:  matchConditions,
 	}
 }
 
@@ -218,7 +228,12 @@ func extractVAPV1CelInformation(policy *v1.ValidatingAdmissionPolicy) *CelInform
 	}
 
 	return &CelInformation{
-		name, namespace, variables, validations, auditAnnotations, matchConditions, nil,
+		name:             name,
+		namespace:        namespace,
+		variables:        variables,
+		validations:      validations,
+		auditAnnotations: auditAnnotations,
+		matchConditions:  matchConditions,
 	}
 }
 
@@ -235,7 +250,7 @@ func extractVWV1Beta1CelInformation(webhookConfig *v1beta1.ValidatingWebhookConf
 		webhookMatchConditions = append(webhookMatchConditions, matchConditions)
 	}
 	return &CelInformation{
-		"", "", nil, nil, nil, nil, webhookMatchConditions,
+		webhookMatchConditions: webhookMatchConditions,
 	}
 }
 
@@ -252,7 +267,7 @@ func extractVWV1CelInformation(webhookConfig *v1.ValidatingWebhookConfiguration)
 		webhookMatchConditions = append(webhookMatchConditions, matchConditions)
 	}
 	return &CelInformation{
-		"", "", nil, nil, nil, nil, webhookMatchConditions,
+		webhookMatchConditions: webhookMatchConditions,
 	}
 }
 
@@ -269,7 +284,7 @@ func extractMWV1Beta1CelInformation(webhookConfig *v1beta1.MutatingWebhookConfig
 		webhookMatchConditions = append(webhookMatchConditions, matchConditions)
 	}
 	return &CelInformation{
-		"", "", nil, nil, nil, nil, webhookMatchConditions,
+		webhookMatchConditions: webhookMatchConditions,
 	}
 }
 
@@ -286,6 +301,6 @@ func extractMWV1CelInformation(webhookConfig *v1.MutatingWebhookConfiguration) *
 		webhookMatchConditions = append(webhookMatchConditions, matchConditions)
 	}
 	return &CelInformation{
-		"", "", nil, nil, nil, nil, webhookMatchConditions,
+		webhookMatchConditions: webhookMatchConditions,
 	}
 }


### PR DESCRIPTION
This is preparation for a MutatingAdmissionPolicy mode I have in progress, which adds three fields to `CelInformation`. The seven `&CelInformation{...}` literals in `k8s/extractcelinfo.go` are positional, so every field added to the struct has to be threaded through all seven of them by hand — and that mechanical edit would land in the feature's diff, next to the code that actually does something. Getting it out of the way here keeps that PR to the feature.

Naming the fields is the whole change. The four webhook extractors currently open with `"", "", nil, nil, nil, nil` to reach the single field they do set, and the three ValidatingAdmissionPolicy extractors end in a bare `nil`; both shapes become keyed.

No behaviour change: each key gets the value its position had, and the fields now left out were being written as their own zero values. `go test ./...` and `-race` pass unchanged. They reach four of the seven extractors — the three vap ones and the `v1` `ValidatingWebhookConfiguration` one — since the testdata has no `v1beta1` webhook fixture and no `MutatingWebhookConfiguration` fixture at all; the three uncovered bodies are identical to the covered one.

There is a small benefit beyond the diff size: `name` and `namespace` are both `string`, so transposing those two is the one mistake here the compiler cannot catch. Everything else was already safe — adding a field breaks the count in all seven, and the five slice fields have distinct types.

No issue preceded this, and it is cosmetic, so close it without ceremony if you would rather the churn just rode along with the feature PR when it arrives.

Written with AI assistance (Claude); I have read and tested it, and I will be handling review comments myself.